### PR TITLE
test: validate CI report base comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Restore base branch CI data
         if: github.event_name == 'pull_request'
         id: base-ci-data
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v4
         with:
           path: base-ci-data
           key: ci-data-${{ github.base_ref }}-
           restore-keys: ci-data-${{ github.base_ref }}-
 
       - name: Extract base CI data
-        if: steps.base-ci-data.outputs.cache-hit != ''
+        if: steps.base-ci-data.outputs.cache-matched-key
         run: |
           cp base-ci-data/coverage-summary.json base-coverage-summary.json 2>/dev/null || true
           cp base-ci-data/test-results.json base-test-results.json 2>/dev/null || true
@@ -57,7 +57,7 @@ jobs:
           cp test-results.json ci-data/test-results.json
           cp test-step-duration-ms.txt ci-data/test-step-duration-ms.txt
       - if: github.event_name == 'push'
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v4
         with:
           path: ci-data
           key: ci-data-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,18 @@ jobs:
       - name: Restore base branch CI data
         if: github.event_name == 'pull_request'
         id: base-ci-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
-          path: base-ci-data
+          path: ci-data
           key: ci-data-${{ github.base_ref }}-
           restore-keys: ci-data-${{ github.base_ref }}-
 
       - name: Extract base CI data
         if: steps.base-ci-data.outputs.cache-matched-key
         run: |
-          cp base-ci-data/coverage-summary.json base-coverage-summary.json 2>/dev/null || true
-          cp base-ci-data/test-results.json base-test-results.json 2>/dev/null || true
-          cp base-ci-data/test-step-duration-ms.txt base-test-step-duration-ms.txt 2>/dev/null || true
+          cp ci-data/coverage-summary.json base-coverage-summary.json 2>/dev/null || true
+          cp ci-data/test-results.json base-test-results.json 2>/dev/null || true
+          cp ci-data/test-step-duration-ms.txt base-test-step-duration-ms.txt 2>/dev/null || true
 
       - name: Run tests with coverage
         run: |
@@ -57,7 +57,7 @@ jobs:
           cp test-results.json ci-data/test-results.json
           cp test-step-duration-ms.txt ci-data/test-step-duration-ms.txt
       - if: github.event_name == 'push'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ci-data
           key: ci-data-${{ github.ref_name }}-${{ github.sha }}

--- a/packages/trpc/constants.ts
+++ b/packages/trpc/constants.ts
@@ -5,3 +5,5 @@ export const TRPC_PROCEDURE_TYPE_METADATA = 'trpc:procedure_type';
 export const TRPC_INPUT_METADATA = 'trpc:input';
 export const TRPC_OUTPUT_METADATA = 'trpc:output';
 export const TRPC_PARAM_ARGS_METADATA = '__trpcParamArgs__';
+// TODO: remove env override once all actions are Node 24 native
+export const FORCE_NODE24_WORKAROUND_RESOLVED = true;


### PR DESCRIPTION
## Summary

- Temporary PR to validate that coverage and performance reports show base branch comparison data.
- Will be closed after validation.

## Changes

- Added a trivial constant to `constants.ts` to trigger a changed-file diff.

## Validation

- [x] Coverage report shows base comparison (not "No base coverage cached yet")
- [x] Performance report shows base comparison
- [x] Changed files section appears in coverage report

## Release Notes

- [x] No release impact