### PR TITLE
chore: remove test constant used for CI report validation

### DIFF
--- a/packages/trpc/constants.ts
+++ b/packages/trpc/constants.ts
@@ -5,5 +5,3 @@ export const TRPC_PROCEDURE_TYPE_METADATA = 'trpc:procedure_type';
 export const TRPC_INPUT_METADATA = 'trpc:input';
 export const TRPC_OUTPUT_METADATA = 'trpc:output';
 export const TRPC_PARAM_ARGS_METADATA = '__trpcParamArgs__';
-// TODO: remove env override once all actions are Node 24 native
-export const FORCE_NODE24_WORKAROUND_RESOLVED = true;


### PR DESCRIPTION
## Summary

- Removes the trivial constant added to validate CI coverage/performance reports.
- Also validates v5 cache base comparison end-to-end.

## Changes

- Removed `FORCE_NODE24_WORKAROUND_RESOLVED` from `constants.ts`

## Validation

- [x] `npm run test:cov`
- [x] `npm run release:check`
- [x] `npm run ci`

## Release Notes

- [x] No release impact

## Publishing Checklist

- [x] Reviewed `RELEASING.md`
- [x] Reviewed the mandatory pre/post-publish checklist in `AI_CODING_GUIDELINES.md`