### PR TITLE
Document API tiers and claims matrix

### DIFF
--- a/website/docs/reference/claims-matrix.md
+++ b/website/docs/reference/claims-matrix.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 2
+---
+
+# Claims Matrix
+
+This page maps the main public claims to current verification evidence. It is a release-readiness checklist, not marketing copy.
+
+## Runtime and API Claims
+
+| Claim | Current evidence | Status |
+| --- | --- | --- |
+| Primary setup uses `TrpcModule.forRoot()` and `forRootAsync()`. | `packages/trpc/test/module/trpc-module.spec.ts`, `website/docs/module-setup/for-root.md`, `website/docs/module-setup/for-root-async.md` | Covered by package tests and docs. |
+| Routers are decorator-first classes. | `packages/trpc/test/decorators/decorators.spec.ts`, `packages/trpc/test/router/trpc-router.spec.ts`, `sample/00-showcase/src/users/users.router.ts` | Covered by package tests and samples. |
+| `@Query()`, `@Mutation()`, and `@Subscription()` map procedures. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `packages/trpc/test/router/trpc-router.spec.ts`, `sample/06-subscriptions` | Covered by package tests and samples. |
+| `@Input()` supports full input and field extraction. | `packages/trpc/test/context/trpc-context-creator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `website/docs/decorators/input.md` | Covered by package tests and docs. |
+| `@TrpcContext()` supports full context and field extraction. | `packages/trpc/test/context/trpc-context-creator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/03-context-request-scope` | Covered by package tests and samples. |
+| `autoSchemaFile` generates importable `AppRouter` types. | `packages/trpc/test/generators/schema-generator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/08-autoschema-client-typecheck/src/client.typecheck.ts` | Covered by package tests and client typecheck sample. |
+| `TrpcRouter` is supported for in-process testing. | `website/docs/testing/router-testing.md`, `packages/trpc/test/router/trpc-router.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts` | Covered as advanced testing API. |
+
+## NestJS Integration Claims
+
+| Claim | Current evidence | Status |
+| --- | --- | --- |
+| Guards execute for tRPC procedures. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `packages/trpc/test/context/trpc-enhancer-runtime.factory.spec.ts`, `sample/02-enhancers-guards-pipes-filters` | Covered by package tests and samples. |
+| Pipes execute for tRPC procedures. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `website/docs/enhancers/pipes.md`, `sample/02-enhancers-guards-pipes-filters` | Covered by package tests and samples. |
+| Interceptors execute for tRPC procedures. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `website/docs/enhancers/interceptors.md`, `sample/02-enhancers-guards-pipes-filters` | Covered by package tests and samples. |
+| Filters can remap procedure errors. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `website/docs/enhancers/filters.md`, `sample/02-enhancers-guards-pipes-filters` | Covered by package tests and samples. |
+| Request-scoped providers work with tRPC calls. | `packages/trpc/test/router/trpc-router.spec.ts`, `website/docs/advanced/request-scope.md`, `sample/03-context-request-scope`, `sample/00-showcase/scripts/smoke-express.ts` | Covered by package tests and smoke samples. |
+| NestJS internals are isolated behind a compatibility boundary. | `website/docs/advanced/nest-internals.md`, `packages/trpc/context/trpc-enhancer-runtime.factory.ts` | Documented and isolated in code. |
+
+## Adapter, Validation, and Client Claims
+
+| Claim | Current evidence | Status |
+| --- | --- | --- |
+| Express is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/00-showcase/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-express.ts` | Covered by package tests and smoke samples. |
+| Fastify is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/00-showcase/scripts/smoke-fastify.ts`, `sample/07-express-fastify/scripts/smoke-fastify.ts` | Covered by package tests and smoke samples. |
+| Zod input and output schemas are supported. | `packages/trpc/test/generators/zod-serializer.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/04-validation-zod` | Covered by package tests and samples. |
+| Zod is optional. | `packages/trpc/package.json`, `website/docs/installation.md`, `website/docs/validation/class-validator.md`, `sample/05-validation-class-validator` | Covered by package metadata, docs, and samples. |
+| `class-validator` plus `ValidationPipe` DTO workflows are supported. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/05-validation-class-validator`, `website/docs/validation/class-validator.md` | Covered by package tests and samples. |
+| Generated `AppRouter` works with `createTRPCProxyClient`. | `sample/00-showcase/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-express.ts`, `sample/08-autoschema-client-typecheck/src/client.typecheck.ts` | Covered by smoke and typecheck samples. |
+
+## Release and Packaging Claims
+
+| Claim | Current evidence | Status |
+| --- | --- | --- |
+| Published package keeps zero runtime dependencies. | `packages/trpc/package.json`, `scripts/check-package-pack.mjs` | Covered by package metadata and release pack check. |
+| Package and sample versions stay synchronized for releases. | `scripts/check-version-sync.mjs`, `RELEASING.md` | Covered by release check and release docs. |
+| README links stay valid. | `scripts/check-readme-links.mjs`, `npm run release:check:readme-links` | Covered by release check. |
+| Package tarball excludes unintended artifacts. | `scripts/check-package-pack.mjs`, `npm run release:check:pack` | Covered by release check. |
+
+## Known Verification Gaps
+
+These gaps should guide future PRs:
+
+- Add package-level real `@trpc/client` E2E tests that boot Nest apps on both Express and Fastify. Current real-client coverage mostly lives in runnable samples.
+- Add a dedicated duplicate-router/procedure-name validation test once runtime diagnostics are improved.
+- Add golden tests for generated schema formatting if output formatting becomes part of the release claim.
+- Keep benchmark claims out of README and docs until a reproducible benchmark harness exists.
+
+## Unsupported Claim Examples
+
+Do not make these claims unless new code, docs, and tests are added:
+
+- "Official NestJS integration."
+- "Production security is handled by the library."
+- "Benchmarked faster than REST, GraphQL, or vanilla tRPC."
+- "All package internals are stable extension points."

--- a/website/docs/reference/public-api.md
+++ b/website/docs/reference/public-api.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+---
+
+# Public API Reference
+
+This page documents the current top-level package entrypoint. It is intentionally narrower than the implementation surface in `packages/trpc`.
+
+Import from the package root:
+
+```ts
+import { Router, Query, TrpcModule } from 'nest-trpc-native';
+```
+
+Do not deep-import from `nest-trpc-native/dist/...` or package internals.
+
+## Primary Onboarding API
+
+These are the APIs intended for installation docs, quick starts, samples, and normal application code.
+
+| Export | Purpose | Notes |
+| --- | --- | --- |
+| `TrpcModule` | Registers the tRPC endpoint and router discovery in a Nest module. | Use `forRoot()` or `forRootAsync()`. |
+| `Router` | Marks a class as a tRPC router. | Accepts an optional alias such as `users` or `admin.users`. |
+| `Query` | Marks a method as a tRPC query procedure. | Can receive `input` and `output` schemas. |
+| `Mutation` | Marks a method as a tRPC mutation procedure. | Can receive `input` and `output` schemas. |
+| `Subscription` | Marks a method as a tRPC subscription procedure. | Async generators are the recommended model. |
+| `Input` | Injects the full input or an input field into a procedure parameter. | Works with Zod and DTO validation. |
+| `TrpcContext` | Injects the full context or a context field into a procedure parameter. | Context comes from `createContext`. |
+| `TrpcModuleOptions` | Type for static module configuration. | Type-only export. |
+| `TrpcModuleAsyncOptions` | Type for async module configuration. | Type-only export. |
+
+## Advanced Testing API
+
+| Export | Purpose | Support tier |
+| --- | --- | --- |
+| `TrpcRouter` | Lets tests access `getRouter().createCaller(...)` after a Nest testing module initializes. | Supported for testing and advanced in-process callers. |
+
+`TrpcRouter` is intentionally absent from installation and quick-start examples. Prefer real application setup through `TrpcModule` and decorator-discovered routers.
+
+## Low-Level Compatibility Exports
+
+| Export | Purpose | Guidance |
+| --- | --- | --- |
+| `ProcedureType` | Procedure kind enum used internally by metadata and schema generation. | Public for current compatibility, but not needed for normal application code. |
+| `TrpcParamtype` | Parameter metadata enum used internally by `@Input()` and `@TrpcContext()`. | Public for current compatibility, but not needed for normal application code. |
+
+These exports remain in the root entrypoint today because the package currently tests them as part of the public entrypoint. Treat them as low-level compatibility exports, not as recommended extension points.
+
+## Unsupported Internals
+
+These are not supported application APIs:
+
+- deep imports into package internals
+- metadata constants and DI tokens
+- context/runtime helper classes
+- schema generator helper functions
+- transport internals such as `TrpcHttpAdapter`
+- request storage internals
+
+If an application needs one of these internals, open a feature request describing the use case so the project can consider a supported abstraction.

--- a/website/docs/support-policy.md
+++ b/website/docs/support-policy.md
@@ -27,6 +27,8 @@ Your router classes and decorators should work the same across both adapters.
 
 ## Supported Public API
 
+The package has three support tiers. Keeping those tiers distinct prevents quick-start docs from accidentally turning testing helpers or internals into application APIs.
+
 ### Primary onboarding API
 
 These are the APIs intended for installation docs, quick starts, and copy-paste usage:
@@ -44,6 +46,17 @@ These are the APIs intended for installation docs, quick starts, and copy-paste 
 
 - `TrpcRouter` is supported for in-process testing via `getRouter().createCaller(...)`.
 
+`TrpcRouter` should stay in testing-oriented guidance. It should not replace the normal application setup path based on `TrpcModule`, decorators, and generated `AppRouter` types.
+
+### Low-level compatibility exports
+
+These exports are public because they are part of the current top-level package entrypoint, but they are not onboarding APIs:
+
+- `ProcedureType`
+- `TrpcParamtype`
+
+They are intended for compatibility with existing low-level metadata or test integrations. New application code should usually not need them. If future `0.x` work removes or replaces them, the project should document that migration separately instead of silently changing the package entrypoint.
+
 ## Unsupported Internal Surface
 
 The following are implementation details and should not be treated as stable application APIs:
@@ -55,3 +68,5 @@ The following are implementation details and should not be treated as stable app
 - metadata constants and DI tokens intended for package internals
 
 These internals may change during `0.x` stabilization without being treated as a breaking change.
+
+For a table view of the current exports and evidence behind public claims, see [Public API Reference](./reference/public-api) and [Claims Matrix](./reference/claims-matrix).

--- a/website/docs/testing/router-testing.md
+++ b/website/docs/testing/router-testing.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 This guide shows pragmatic testing layers for `nest-trpc-native` routers.
 
-`TrpcRouter` is a supported advanced testing API. It is appropriate in tests, but it should not replace the main onboarding path centered on `TrpcModule`, decorators, and generated `AppRouter` types.
+`TrpcRouter` is a supported advanced testing API. It is appropriate in tests, but it should not replace the main onboarding path centered on `TrpcModule`, decorators, and generated `AppRouter` types. See [Public API Reference](../reference/public-api) for the full support-tier breakdown.
 
 ## Testing Strategy
 

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -4,8 +4,16 @@ const sidebars: SidebarsConfig = {
   docsSidebar: [
     'introduction',
     'installation',
-    'support-policy',
     'quick-start',
+    {
+      type: 'category',
+      label: 'Support & Reference',
+      items: [
+        'support-policy',
+        'reference/public-api',
+        'reference/claims-matrix',
+      ],
+    },
     {
       type: 'category',
       label: 'Samples',


### PR DESCRIPTION
## Summary

Documents the package's public API support tiers and adds a release-readiness claims matrix for the current docs/tests/samples evidence.

## Changes

- Adds a public API reference page that separates onboarding APIs, advanced testing APIs, low-level compatibility exports, and unsupported internals.
- Adds a claims matrix mapping public claims to package tests, docs, samples, and known verification gaps.
- Updates the support policy with explicit support tiers for TrpcRouter, ProcedureType, and TrpcParamtype.
- Adds the new reference pages to the Docusaurus sidebar and links router testing back to the API tier reference.

## Validation

- git diff --check
- npm run release:check:readme-links
- npm run docs:test:typecheck
- npm --prefix website ci
- npm --prefix website run build

## Notes

- Docusaurus build succeeded. It emitted an update-check warning about access to /home/rodrigo/.config, but static files were generated successfully.
- npm --prefix website ci reported existing audit findings in the website dependency tree; this PR does not change dependencies or lockfiles.
