### PR TITLE
Add production and client guidance

### DIFF
--- a/website/docs/advanced/production-practices.md
+++ b/website/docs/advanced/production-practices.md
@@ -1,0 +1,79 @@
+---
+sidebar_position: 9
+---
+
+# Production Practices
+
+`nest-trpc-native` keeps the router layer close to normal NestJS applications. Production readiness still depends on the surrounding Nest app, deployment platform, and client behavior.
+
+## Keep Router Code Boring
+
+- Put business logic in injectable services.
+- Keep router methods small and intention-revealing.
+- Use `@Input()` and `@TrpcContext()` for procedure boundaries.
+- Use Nest enhancers for cross-cutting behavior instead of custom procedure wrappers.
+- Keep Express and Fastify behavior adapter-neutral unless a feature truly requires adapter-specific code.
+
+## Validate Inputs Deliberately
+
+Both validation styles are supported:
+
+- Zod schemas in procedure options.
+- DTO classes with `class-validator` and `ValidationPipe`.
+
+Pick the style that fits the application boundary. Avoid accepting unvalidated objects in procedures that mutate state, perform authorization decisions, or call external systems.
+
+## Handle Errors As Public API
+
+Client-visible errors become part of the API contract. Prefer stable error shapes and messages:
+
+- Throw `TRPCError` when you want explicit tRPC codes.
+- Throw Nest `HttpException` subclasses when the procedure follows existing Nest service behavior.
+- Use exception filters when a domain error needs consistent mapping.
+
+For examples, see [Idiomatic Error Handling](../errors/idiomatic-errors) and [Advanced Error Handling](./error-handling).
+
+## Preserve Request Context Boundaries
+
+Context should contain request-scoped values that procedures need, such as request IDs, authenticated subject IDs, locale, or tenant IDs.
+
+Do not use context as a generic global object. If a value needs lifecycle, caching, cleanup, or dependencies, prefer a request-scoped provider.
+
+See [Typed Context](../module-setup/typed-context) and [Request Scope](./request-scope).
+
+## Review Adapter Parity
+
+If a change touches request handling, headers, status mapping, subscriptions, or context creation, validate both adapters:
+
+```bash
+npm run smoke:express --workspace nest-trpc-native-showcase
+npm run smoke:fastify --workspace nest-trpc-native-showcase
+```
+
+Router classes should not need to change when the app switches between Express and Fastify.
+
+## Watch Complexity And Coverage
+
+Use the package test suite and complexity report as review signals:
+
+```bash
+npm run test
+npm run complexity:report
+```
+
+Run coverage when behavior changes:
+
+```bash
+npm run test:cov
+```
+
+The complexity report is not a merge gate by itself. It should help reviewers spot code that needs a smaller shape, clearer names, or stronger tests.
+
+## Release Checklist
+
+Before relying on a production claim in docs or release notes, make sure it has executable support:
+
+- A package test, focused sample, or showcase smoke check covers the behavior.
+- The claim appears in the [Claims Matrix](../reference/claims-matrix).
+- README and package README use the same compatibility and support language.
+- New dependencies have a written reason and do not affect the published library runtime dependency contract.

--- a/website/docs/advanced/security-responsibilities.md
+++ b/website/docs/advanced/security-responsibilities.md
@@ -1,0 +1,109 @@
+---
+sidebar_position: 10
+---
+
+# Security Responsibilities
+
+`nest-trpc-native` provides a Nest-native tRPC transport layer. It does not replace application security design.
+
+## What The Library Provides
+
+The library helps route tRPC calls through Nest patterns:
+
+- Router discovery through decorators.
+- Procedure input handling through `@Input()`.
+- Context access through `@TrpcContext()`.
+- Nest guards, interceptors, pipes, and filters around procedures.
+- Express and Fastify adapter support.
+
+These pieces let you apply normal Nest security controls to tRPC procedures.
+
+## What Your Application Must Provide
+
+Applications remain responsible for:
+
+- Authentication policy.
+- Authorization rules.
+- Rate limiting.
+- Production CORS policy.
+- CSRF posture for browser clients.
+- Request body limits.
+- Secret handling.
+- Tenant isolation.
+- Audit logging.
+
+Do not document an application as secure just because its procedures use tRPC types. Type safety and validation reduce mistakes, but they do not define who can call a procedure or what they may access.
+
+## Authentication And Authorization
+
+Use guards for authentication and authorization decisions:
+
+```ts
+@Router('admin')
+@UseGuards(AdminGuard)
+class AdminRouter {
+  @Query()
+  dashboard() {
+    return { ok: true };
+  }
+}
+```
+
+Class-level guards protect every procedure in the router. Method-level guards are useful when one procedure has stricter requirements.
+
+## Input Validation
+
+Validate every external input that influences persistence, authorization, external calls, file paths, or dynamic query construction.
+
+```ts
+import { z } from 'zod';
+
+const UpdateUserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string().min(1).max(80),
+});
+
+@Mutation({ input: UpdateUserSchema })
+update(@Input() input: z.infer<typeof UpdateUserSchema>) {
+  return this.users.update(input);
+}
+```
+
+DTO validation with `ValidationPipe` is also supported. Pick one validation style per boundary when possible so reviews stay simple.
+
+## Context Data
+
+Keep context data minimal:
+
+- Prefer stable identifiers over full user records.
+- Do not store secrets in context.
+- Avoid passing raw tokens to procedure return values or logs.
+- Recompute authorization-sensitive data when freshness matters.
+
+If a value needs dependencies or request lifecycle behavior, use a request-scoped provider instead of expanding the context object.
+
+## Transport Settings
+
+Configure transport-level security in the Nest application or deployment layer:
+
+- CORS.
+- HTTPS termination.
+- proxy trust.
+- body size limits.
+- compression policy.
+- rate limiting.
+
+The correct settings depend on the hosting environment and client type, so this package does not provide a universal production default.
+
+## Review Checklist
+
+For security-sensitive changes, reviewers should ask:
+
+- Which guard protects this procedure?
+- Is every external input validated?
+- Does context expose only the data procedures need?
+- Are errors safe for clients to see?
+- Could this procedure leak another tenant's data?
+- Are secrets absent from docs, tests, examples, and logs?
+
+Security issues should be reported privately through the repository security advisory flow. See the repository `SECURITY.md` for disclosure guidance.

--- a/website/docs/client-consumption.md
+++ b/website/docs/client-consumption.md
@@ -1,0 +1,100 @@
+---
+sidebar_position: 8
+---
+
+# Client Consumption
+
+Use the generated `AppRouter` type with `@trpc/client` so application clients stay aligned with the Nest router contract.
+
+## Generate the Router Type
+
+Enable `autoSchemaFile` in the Nest application:
+
+```ts
+TrpcModule.forRoot({
+  path: '/trpc',
+  autoSchemaFile: 'src/@generated/server.ts',
+});
+```
+
+The generated file should be treated as build output. Import its type from client code, but do not edit the file by hand.
+
+## Create a Typed Client
+
+Use `createTRPCProxyClient<AppRouter>()` in the consuming app:
+
+```ts
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from '../server/src/@generated/server';
+
+export const trpc = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({
+      url: 'http://localhost:3000/trpc',
+    }),
+  ],
+});
+```
+
+Procedure calls now follow the router namespace and procedure names:
+
+```ts
+const users = await trpc.users.list.query();
+const created = await trpc.users.create.mutate({ name: 'Ada' });
+```
+
+## Share Types In A Monorepo
+
+In a monorepo, prefer one shared type export rather than deep imports between apps:
+
+```ts title="packages/api-contract/src/index.ts"
+export type { AppRouter } from '../../apps/api/src/@generated/server';
+```
+
+```ts title="apps/web/src/trpc.ts"
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import type { AppRouter } from '@acme/api-contract';
+
+export const trpc = createTRPCProxyClient<AppRouter>({
+  links: [httpBatchLink({ url: '/trpc' })],
+});
+```
+
+Keep that contract package type-only. It should not import Nest modules, providers, or runtime server code into the client bundle.
+
+## Validate Client Drift
+
+Add a typecheck-only client file when router changes should be reviewed from the consumer side:
+
+```ts title="src/client.typecheck.ts"
+import { createTRPCProxyClient } from '@trpc/client';
+import type { AppRouter } from './@generated/server';
+
+declare const trpc: ReturnType<typeof createTRPCProxyClient<AppRouter>>;
+
+void trpc.users.list.query();
+void trpc.users.create.mutate({ name: 'Ada' });
+```
+
+Run the client typecheck in CI or before release:
+
+```bash
+npx tsc --noEmit -p tsconfig.client.json
+```
+
+The showcase demonstrates this with:
+
+```bash
+npm run typecheck:client --workspace nest-trpc-native-showcase
+```
+
+## Runtime Configuration
+
+Client setup is application-owned:
+
+- Resolve the base URL from your deployment environment.
+- Add auth headers through `headers` or a custom link.
+- Keep secrets on the server; do not export server-only configuration through generated types.
+- Use subscriptions only when the server and client deployment path both support streaming.
+
+For schema generation details, see [Schema Generation](./schema-generation). For a runnable client, see the [showcase sample](./samples).

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -59,3 +59,6 @@ NestJS has a proven architecture with guards, interceptors, pipes, filters, and 
 - [Installation](./installation) — set up the package
 - [Support Policy](./support-policy) — see the supported versions and API tiers
 - [Quick Start](./quick-start) — build your first router in minutes
+- [Client Consumption](./client-consumption) — consume generated `AppRouter` types from applications
+- [Production Practices](./advanced/production-practices) — review production readiness signals
+- [Security Responsibilities](./advanced/security-responsibilities) — separate library behavior from app security

--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -109,6 +109,9 @@ const created = await trpc.users.create.mutate({ name: 'Bob' });
 - [Decorators](./decorators/router) — `@Router`, `@Query`, `@Mutation`, `@Subscription`
 - [Enhancers](./enhancers/guards) — guards, interceptors, pipes, filters
 - [Samples](./samples) — runnable showcase + focused examples by topic
+- [Client Consumption](./client-consumption) — wire generated `AppRouter` types into clients
+- [Production Practices](./advanced/production-practices) — production review checklist
+- [Security Responsibilities](./advanced/security-responsibilities) — app-owned security boundaries
 - [Router Testing](./testing/router-testing) — in-process, HTTP smoke, and client typecheck layers
 - [Idiomatic Error Handling](./errors/idiomatic-errors) — Nest exceptions, filters, and tRPC codes
 - [Migration from REST/GraphQL](./advanced/migration-from-rest-or-graphql) — map existing controllers/resolvers to routers

--- a/website/docs/reference/claims-matrix.md
+++ b/website/docs/reference/claims-matrix.md
@@ -63,6 +63,6 @@ These gaps should guide future PRs:
 Do not make these claims unless new code, docs, and tests are added:
 
 - "Official NestJS integration."
-- "Production security is handled by the library."
+- "Production security is handled by the library." Authentication, authorization, rate limiting, CORS, and secret handling are application responsibilities. See [Security Responsibilities](../advanced/security-responsibilities).
 - "Benchmarked faster than REST, GraphQL, or vanilla tRPC."
 - "All package internals are stable extension points."

--- a/website/docs/schema-generation.md
+++ b/website/docs/schema-generation.md
@@ -42,6 +42,8 @@ const cats = await trpc.cats.list.query();
 const user = await trpc.users.create.mutate({ name: 'Ada' });
 ```
 
+For multi-app and monorepo patterns, see [Client Consumption](./client-consumption).
+
 ## Compile-Time Client Checking
 
 Create a typecheck-only file to ensure your client calls stay in sync:

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -61,6 +61,7 @@ const sidebars: SidebarsConfig = {
       items: ['testing/router-testing', 'errors/idiomatic-errors'],
     },
     'schema-generation',
+    'client-consumption',
     'express-and-fastify',
     {
       type: 'category',
@@ -73,6 +74,8 @@ const sidebars: SidebarsConfig = {
         'advanced/migration-from-rest-or-graphql',
         'advanced/transport-pattern-parallels',
         'advanced/error-handling',
+        'advanced/production-practices',
+        'advanced/security-responsibilities',
         'advanced/benchmark-methodology',
         'advanced/nest-internals',
       ],


### PR DESCRIPTION
## Summary

Adds docs for consuming generated router types from clients and clarifies production and security responsibilities for applications using nest-trpc-native.

## Changes

- Adds a Client Consumption page for generated AppRouter usage, monorepo type sharing, client drift checks, and runtime client configuration.
- Adds a Production Practices page covering router shape, validation, errors, context boundaries, adapter parity, complexity, coverage, and release claims.
- Adds a Security Responsibilities page that separates library behavior from app-owned authentication, authorization, CORS, rate limiting, request limits, and secret handling.
- Links the new pages from introduction, quick start, schema generation, claims matrix, and the Docusaurus sidebar.

## Validation

- git diff --check
- npm run docs:test:typecheck
- npm --prefix website run build

## Notes

- Documentation-only change.
- No benchmark numbers or new security guarantees are introduced.