### PR TITLE
Add real client adapter E2E coverage

### DIFF
--- a/packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts
+++ b/packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts
@@ -1,0 +1,226 @@
+import {
+  INestApplication,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  FastifyAdapter,
+  NestFastifyApplication,
+} from '@nestjs/platform-fastify';
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  createTRPCProxyClient,
+  httpBatchLink,
+  httpSubscriptionLink,
+  splitLink,
+} from '@trpc/client';
+import { expect } from 'chai';
+import { EventSource } from 'eventsource';
+import { IsString, MinLength } from 'class-validator';
+import { z } from 'zod';
+import { TrpcContext } from '../../decorators/ctx.decorator';
+import { Input } from '../../decorators/input.decorator';
+import {
+  Mutation,
+  Query,
+  Subscription,
+} from '../../decorators/procedure.decorator';
+import { Router } from '../../decorators/router.decorator';
+import { TrpcModule } from '../../trpc.module';
+
+const TRPC_PATH = '/trpc';
+const REQUEST_ID_HEADER = 'x-trpc-test-request-id';
+
+const CreateItemSchema = z.object({
+  name: z.string().min(1),
+});
+
+class CreateDtoItem {
+  @IsString()
+  @MinLength(3)
+  name!: string;
+}
+
+@Router('client')
+class ClientE2ERouter {
+  @Query({
+    output: z.array(z.object({ id: z.string(), name: z.string() })),
+  })
+  list(@TrpcContext('requestId') requestId: string) {
+    return [{ id: requestId, name: 'Item 1' }];
+  }
+
+  @Mutation({
+    input: CreateItemSchema,
+    output: z.object({
+      id: z.string(),
+      name: z.string(),
+      upperName: z.string(),
+    }),
+  })
+  create(
+    @Input() input: z.infer<typeof CreateItemSchema>,
+    @Input('name') name: string,
+    @TrpcContext('requestId') requestId: string,
+  ) {
+    return {
+      id: requestId,
+      name: input.name,
+      upperName: name.toUpperCase(),
+    };
+  }
+
+  @Mutation({ input: z.any() })
+  @UsePipes(new ValidationPipe({ transform: true, whitelist: true }))
+  createDto(@Input() input: CreateDtoItem) {
+    return {
+      isDtoInstance: input instanceof CreateDtoItem,
+      name: input.name,
+    };
+  }
+
+  @Subscription({
+    input: z.object({ count: z.number().int().min(1).max(3) }),
+    output: z.object({ tick: z.number() }),
+  })
+  async *ticks(@Input('count') count: number) {
+    for (let tick = 1; tick <= count; tick += 1) {
+      yield { tick };
+    }
+  }
+}
+
+type AdapterKind = 'express' | 'fastify';
+
+async function createTestingApp(kind: AdapterKind): Promise<INestApplication> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    imports: [
+      TrpcModule.forRoot({
+        path: TRPC_PATH,
+        createContext: ({ req }) => ({
+          requestId: req.headers?.[REQUEST_ID_HEADER] ?? 'missing',
+        }),
+      }),
+    ],
+    providers: [ClientE2ERouter],
+  }).compile();
+
+  const app =
+    kind === 'fastify'
+      ? moduleRef.createNestApplication<NestFastifyApplication>(
+          new FastifyAdapter(),
+        )
+      : moduleRef.createNestApplication();
+
+  await app.init();
+  await app.listen(0, '127.0.0.1');
+  return app;
+}
+
+function createClient(baseUrl: string, requestId: string) {
+  return createTRPCProxyClient<any>({
+    links: [
+      splitLink({
+        condition: operation => operation.type === 'subscription',
+        true: httpSubscriptionLink({
+          url: `${baseUrl}${TRPC_PATH}`,
+          EventSource,
+        }),
+        false: httpBatchLink({
+          url: `${baseUrl}${TRPC_PATH}`,
+          headers: {
+            [REQUEST_ID_HEADER]: requestId,
+          },
+        }),
+      }),
+    ],
+  });
+}
+
+async function expectClientError(
+  run: () => Promise<unknown>,
+  expectedMessage: RegExp,
+) {
+  let error: Error | undefined;
+  try {
+    await run();
+  } catch (err) {
+    error = err as Error;
+  }
+
+  expect(error).to.be.instanceOf(Error);
+  expect(String(error?.message)).to.match(expectedMessage);
+}
+
+describe('real @trpc/client adapter E2E', () => {
+  for (const adapterKind of ['express', 'fastify'] as const) {
+    describe(adapterKind, () => {
+      let app: INestApplication;
+      let client: any;
+      let requestId: string;
+
+      before(async () => {
+        app = await createTestingApp(adapterKind);
+        requestId = `client-e2e-${adapterKind}`;
+        client = createClient(await app.getUrl(), requestId);
+      });
+
+      after(async () => {
+        await app?.close();
+      });
+
+      it('handles typed queries, mutations, and context extraction', async () => {
+        const items = await client.client.list.query();
+        expect(items).to.deep.equal([{ id: requestId, name: 'Item 1' }]);
+
+        const created = await client.client.create.mutate({ name: 'Ada' });
+        expect(created).to.deep.equal({
+          id: requestId,
+          name: 'Ada',
+          upperName: 'ADA',
+        });
+      });
+
+      it('reports Zod input errors through the real client', async () => {
+        await expectClientError(
+          () => client.client.create.mutate({ name: '' }),
+          /(too small|minimum|name|string)/i,
+        );
+      });
+
+      it('runs class-validator DTO validation through ValidationPipe', async () => {
+        const valid = await client.client.createDto.mutate({ name: 'Ada' });
+        expect(valid).to.deep.equal({ isDtoInstance: true, name: 'Ada' });
+
+        await expectClientError(
+          () => client.client.createDto.mutate({ name: 'Al' }),
+          /(least|minimal|3|name)/i,
+        );
+      });
+
+      it('streams subscriptions through the real client', async function () {
+        this.timeout(5000);
+
+        const ticks: number[] = [];
+        await new Promise<void>((resolve, reject) => {
+          client.client.ticks.subscribe(
+            { count: 3 },
+            {
+              onData(event: { tick: number }) {
+                ticks.push(event.tick);
+              },
+              onError(error: unknown) {
+                reject(error);
+              },
+              onComplete() {
+                resolve();
+              },
+            },
+          );
+        });
+
+        expect(ticks).to.deep.equal([1, 2, 3]);
+      });
+    });
+  }
+});

--- a/website/docs/reference/claims-matrix.md
+++ b/website/docs/reference/claims-matrix.md
@@ -33,11 +33,12 @@ This page maps the main public claims to current verification evidence. It is a 
 
 | Claim | Current evidence | Status |
 | --- | --- | --- |
-| Express is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/00-showcase/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-express.ts` | Covered by package tests and smoke samples. |
-| Fastify is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/00-showcase/scripts/smoke-fastify.ts`, `sample/07-express-fastify/scripts/smoke-fastify.ts` | Covered by package tests and smoke samples. |
-| Zod input and output schemas are supported. | `packages/trpc/test/generators/zod-serializer.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/04-validation-zod` | Covered by package tests and samples. |
+| Express is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/00-showcase/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-express.ts` | Covered by package tests and smoke samples. |
+| Fastify is supported. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/00-showcase/scripts/smoke-fastify.ts`, `sample/07-express-fastify/scripts/smoke-fastify.ts` | Covered by package tests and smoke samples. |
+| Zod input and output schemas are supported. | `packages/trpc/test/generators/zod-serializer.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/04-validation-zod` | Covered by package tests and samples. |
 | Zod is optional. | `packages/trpc/package.json`, `website/docs/installation.md`, `website/docs/validation/class-validator.md`, `sample/05-validation-class-validator` | Covered by package metadata, docs, and samples. |
-| `class-validator` plus `ValidationPipe` DTO workflows are supported. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/05-validation-class-validator`, `website/docs/validation/class-validator.md` | Covered by package tests and samples. |
+| `class-validator` plus `ValidationPipe` DTO workflows are supported. | `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/05-validation-class-validator`, `website/docs/validation/class-validator.md` | Covered by package tests and samples. |
+| Real `@trpc/client` calls work against Express and Fastify adapters. | `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/00-showcase/scripts/smoke-express.ts`, `sample/00-showcase/scripts/smoke-fastify.ts`, `sample/07-express-fastify/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-fastify.ts` | Covered by package tests and smoke samples. |
 | Generated `AppRouter` works with `createTRPCProxyClient`. | `sample/00-showcase/scripts/smoke-express.ts`, `sample/07-express-fastify/scripts/smoke-express.ts`, `sample/08-autoschema-client-typecheck/src/client.typecheck.ts` | Covered by smoke and typecheck samples. |
 
 ## Release and Packaging Claims
@@ -53,7 +54,6 @@ This page maps the main public claims to current verification evidence. It is a 
 
 These gaps should guide future PRs:
 
-- Add package-level real `@trpc/client` E2E tests that boot Nest apps on both Express and Fastify. Current real-client coverage mostly lives in runnable samples.
 - Add a dedicated duplicate-router/procedure-name validation test once runtime diagnostics are improved.
 - Add golden tests for generated schema formatting if output formatting becomes part of the release claim.
 - Keep benchmark claims out of README and docs until a reproducible benchmark harness exists. See [Benchmark Methodology](../advanced/benchmark-methodology).


### PR DESCRIPTION
## Summary

Adds package-level E2E coverage that boots the same Nest tRPC router on Express and Fastify, then exercises it through real @trpc/client calls.

## Changes

- Adds a real @trpc/client adapter E2E spec for Express and Fastify.
- Covers query, mutation, @Input(), @Input('field'), @TrpcContext(), Zod validation errors, class-validator DTO validation through ValidationPipe, and subscriptions.
- Updates the claims matrix to point adapter, validation, and real-client claims at the new package test.
- Removes the known verification gap for package-level real-client adapter E2E coverage.

## Validation

- git diff --check
- focused adapter/client E2E spec
- npm run test:cov
- npm run docs:test:typecheck

## Notes

- No runtime dependency changes.
- No benchmark numbers or performance claims are introduced.