### PR TITLE
Add router diagnostics

### DIFF
--- a/.github/scripts/complexity-report.js
+++ b/.github/scripts/complexity-report.js
@@ -22,19 +22,23 @@ module.exports = async ({ github, context, core }) => {
   const baseByFile = new Map((base?.files ?? []).map(file => [file.file, file]));
   const currentByFile = new Map(current.files.map(file => [file.file, file]));
 
-  const diffNumber = (currentValue, baseValue) => {
+  const formatDiff = (currentValue, baseValue, { higherIsBad }) => {
     if (baseValue == null) {
       return '🆕 new';
     }
     const diff = currentValue - baseValue;
     if (diff > 0) {
-      return `🔴 +${diff}`;
+      return `${higherIsBad ? '🔴' : '⚪'} +${diff}`;
     }
     if (diff < 0) {
-      return `🟢 ${diff}`;
+      return `${higherIsBad ? '🟢' : '⚪'} ${diff}`;
     }
     return '⚪ 0';
   };
+  const complexityDiff = (currentValue, baseValue) =>
+    formatDiff(currentValue, baseValue, { higherIsBad: true });
+  const neutralDiff = (currentValue, baseValue) =>
+    formatDiff(currentValue, baseValue, { higherIsBad: false });
 
   const status = value => {
     if (value >= 25) {
@@ -59,7 +63,7 @@ module.exports = async ({ github, context, core }) => {
     }
 
     changedRows.push(
-      `| \`${file.replace(/^packages\//, '')}\` | ${currentFile?.totalComplexity ?? 0} | ${currentFile?.maxComplexity ?? 0} | ${currentFile?.functionCount ?? 0} | ${diffNumber(currentFile?.totalComplexity ?? 0, baseFile?.totalComplexity)} |`,
+      `| \`${file.replace(/^packages\//, '')}\` | ${currentFile?.totalComplexity ?? 0} | ${currentFile?.maxComplexity ?? 0} | ${currentFile?.functionCount ?? 0} | ${complexityDiff(currentFile?.totalComplexity ?? 0, baseFile?.totalComplexity)} |`,
     );
   }
 
@@ -71,9 +75,9 @@ module.exports = async ({ github, context, core }) => {
     '',
     '| Metric | PR | Base | Diff |',
     '| --- | ---: | ---: | ---: |',
-    `| Total complexity | ${current.totals.totalComplexity} | ${baseTotal ?? '-'} | ${diffNumber(current.totals.totalComplexity, baseTotal)} |`,
-    `| Max function complexity | ${current.totals.maxComplexity} | ${baseMax ?? '-'} | ${diffNumber(current.totals.maxComplexity, baseMax)} |`,
-    `| Functions measured | ${current.totals.functions} | ${base?.totals.functions ?? '-'} | ${diffNumber(current.totals.functions, base?.totals.functions)} |`,
+    `| Total complexity | ${current.totals.totalComplexity} | ${baseTotal ?? '-'} | ${complexityDiff(current.totals.totalComplexity, baseTotal)} |`,
+    `| Max function complexity | ${current.totals.maxComplexity} | ${baseMax ?? '-'} | ${complexityDiff(current.totals.maxComplexity, baseMax)} |`,
+    `| Functions measured | ${current.totals.functions} | ${base?.totals.functions ?? '-'} | ${neutralDiff(current.totals.functions, base?.totals.functions)} |`,
     '',
     '<details>',
     '<summary><strong>🧩 Most complex functions</strong></summary>',

--- a/packages/trpc/test/generators/schema-generator.spec.ts
+++ b/packages/trpc/test/generators/schema-generator.spec.ts
@@ -239,6 +239,59 @@ describe('generateSchemaContent', () => {
       '123start: t.procedure.input(schema_unknown__123start_input_0).query(() => undefined as unknown)',
     );
   });
+
+  it('should keep generated schema formatting stable', () => {
+    const content = generateSchemaContent([
+      {
+        alias: 'users',
+        procedures: [
+          {
+            name: 'list',
+            type: ProcedureType.QUERY,
+            inputSchema: z.object({ limit: z.number() }),
+            outputSchema: z.array(z.object({ id: z.string() })),
+          },
+        ],
+      },
+      {
+        procedures: [
+          { name: 'ping', type: ProcedureType.QUERY },
+          {
+            name: 'ticks',
+            type: ProcedureType.SUBSCRIPTION,
+            outputSchema: z.object({ tick: z.number() }),
+          },
+        ],
+      },
+    ]);
+
+    expect(content).to.equal([
+      '// ------------------------------------------------------',
+      '// THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)',
+      '// nest-trpc-native',
+      '// ------------------------------------------------------',
+      '',
+      "import { initTRPC } from '@trpc/server';",
+      "import { z } from 'zod';",
+      '',
+      'const t = initTRPC.create();',
+      '',
+      'const schema_users_list_input_0 = z.object({ limit: z.number() });',
+      'const schema_users_list_output_1 = z.array(z.object({ id: z.string() }));',
+      'const schema_root_ticks_output_2 = z.object({ tick: z.number() });',
+      '',
+      'const appRouter = t.router({',
+      '  users: t.router({',
+      '    list: t.procedure.input(schema_users_list_input_0).output(schema_users_list_output_1).query(() => null as unknown as z.infer<typeof schema_users_list_output_1>),',
+      '  }),',
+      '  ping: t.procedure.query(() => undefined as unknown),',
+      '  ticks: t.procedure.subscription(async function* () { yield null as unknown as z.infer<typeof schema_root_ticks_output_2>; })',
+      '});',
+      '',
+      'export type AppRouter = typeof appRouter;',
+      '',
+    ].join('\n'));
+  });
 });
 
 describe('generateSchema (file output)', () => {

--- a/packages/trpc/test/router/trpc-router.spec.ts
+++ b/packages/trpc/test/router/trpc-router.spec.ts
@@ -5,6 +5,7 @@ import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
 import { STATIC_CONTEXT } from '@nestjs/core/injector/constants';
 import * as sinon from 'sinon';
 import { z } from 'zod';
+import { TRPC_PROCEDURE_METADATA } from '../../constants';
 import { TrpcModule } from '../../trpc.module';
 import { TrpcRouter } from '../../trpc-router';
 import { trpcRequestStorage } from '../../trpc-request-storage';
@@ -52,11 +53,27 @@ class NestedAliasRouter {
   }
 }
 
+@Router('admin.users')
+class DuplicateNestedAliasRouter {
+  @Query()
+  list() {
+    return ['duplicate'];
+  }
+}
+
 @Router('admin.roles')
 class NestedSiblingAliasRouter {
   @Query()
   list() {
     return ['maintainer'];
+  }
+}
+
+@Router('admin')
+class NestedParentAliasRouter {
+  @Query()
+  list() {
+    return ['root'];
   }
 }
 
@@ -96,6 +113,13 @@ class MixedRouter {
   }
 }
 
+@Router('empty')
+class EmptyRouter {
+  helperMethod() {
+    return 'helper';
+  }
+}
+
 @Router('nullproto')
 class NullPrototypeRouter {
   @Query()
@@ -119,6 +143,68 @@ class PrototypeFallbackRouter {
   value() {
     return 'from-prototype';
   }
+}
+
+@Router()
+class DuplicateRootRouter {
+  @Query('ping')
+  duplicatePing() {
+    return 'duplicate';
+  }
+}
+
+@Router('greeting')
+class DuplicateGreetingAliasRouter {
+  @Query()
+  salutation() {
+    return 'hello';
+  }
+}
+
+@Router('invalid')
+class EmptyProcedureNameRouter {
+  @Query('')
+  emptyName() {
+    return 'invalid';
+  }
+}
+
+@Router('broken')
+class MissingProcedureTypeRouter {
+  broken() {
+    return 'broken';
+  }
+}
+Reflect.defineMetadata(
+  TRPC_PROCEDURE_METADATA,
+  'broken',
+  MissingProcedureTypeRouter.prototype.broken,
+);
+
+async function expectModuleInitFailure(
+  providers: any[],
+  expectedMessage: RegExp,
+) {
+  let module: TestingModule | undefined;
+  let error: Error | undefined;
+
+  try {
+    module = await Test.createTestingModule({
+      imports: [TrpcModule.forRoot({ path: '/trpc' })],
+      providers,
+    }).compile();
+
+    await module.init();
+  } catch (err) {
+    error = err as Error;
+  } finally {
+    if (!error) {
+      await module?.close();
+    }
+  }
+
+  expect(error).to.be.instanceOf(Error);
+  expect(String(error?.message)).to.match(expectedMessage);
 }
 
 describe('TrpcRouter', () => {
@@ -214,17 +300,62 @@ describe('TrpcRouter (nested aliases)', () => {
     expect(roles).to.deep.equal(['maintainer']);
   });
 
-  it('should ignore dotted aliases that normalize to empty segments', async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [TrpcModule.forRoot({ path: '/trpc' })],
-      providers: [BlankDottedAliasRouter],
-    }).compile();
+  it('should reject aliases that normalize to empty segments', async () => {
+    await expectModuleInitFailure(
+      [BlankDottedAliasRouter],
+      /Invalid tRPC router alias " \. ".*BlankDottedAliasRouter.*Suggested fix:.*non-empty dotted alias/s,
+    );
+  });
+});
 
-    await module.init();
+describe('TrpcRouter diagnostics', () => {
+  it('should reject duplicate root procedure paths', async () => {
+    await expectModuleInitFailure(
+      [FlatRouter, DuplicateRootRouter],
+      /Duplicate tRPC procedure path "ping".*DuplicateRootRouter\.duplicatePing.*Suggested fix:.*FlatRouter\.ping.*Rename one procedure/s,
+    );
+  });
 
-    const router = module.get(TrpcRouter).getRouter();
-    const procedures = router._def.procedures;
-    expect(Object.keys(procedures)).to.deep.equal([]);
+  it('should reject duplicate aliased procedure paths', async () => {
+    await expectModuleInitFailure(
+      [NestedAliasRouter, DuplicateNestedAliasRouter],
+      /Duplicate tRPC procedure path "admin\.users\.list".*DuplicateNestedAliasRouter\.list.*Suggested fix:.*NestedAliasRouter\.list.*change one router alias/s,
+    );
+  });
+
+  it('should reject duplicate router aliases even when procedure names differ', async () => {
+    await expectModuleInitFailure(
+      [GreetingRouter, DuplicateGreetingAliasRouter],
+      /Duplicate tRPC router alias "greeting".*DuplicateGreetingAliasRouter.*Suggested fix:.*unique router alias/s,
+    );
+  });
+
+  it('should reject aliases that reuse an existing router as a namespace', async () => {
+    await expectModuleInitFailure(
+      [NestedParentAliasRouter, NestedAliasRouter],
+      /Conflicting tRPC router alias "admin\.users".*NestedAliasRouter.*Suggested fix:.*alias "admin" is already registered as a router/s,
+    );
+  });
+
+  it('should reject aliases that replace an existing namespace', async () => {
+    await expectModuleInitFailure(
+      [NestedAliasRouter, NestedParentAliasRouter],
+      /Conflicting tRPC router alias "admin".*NestedParentAliasRouter.*Suggested fix:.*already used as a namespace/s,
+    );
+  });
+
+  it('should reject empty custom procedure names', async () => {
+    await expectModuleInitFailure(
+      [EmptyProcedureNameRouter],
+      /Invalid tRPC procedure name on EmptyProcedureNameRouter\.emptyName.*Suggested fix:.*non-empty name/s,
+    );
+  });
+
+  it('should reject incomplete procedure metadata', async () => {
+    await expectModuleInitFailure(
+      [MissingProcedureTypeRouter],
+      /Invalid tRPC procedure metadata on MissingProcedureTypeRouter\.broken.*procedure "broken".*Suggested fix:.*@Query\(\).*@Mutation\(\).*@Subscription\(\)/s,
+    );
   });
 });
 
@@ -301,6 +432,17 @@ describe('TrpcRouter (edge cases)', () => {
     // Only the decorated method should appear
     expect(procedures).to.have.property('mixed.decorated');
     expect(procedures).to.not.have.property('mixed.helperMethod');
+  });
+
+  it('should skip routers with no procedure decorators', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TrpcModule.forRoot({ path: '/trpc' })],
+      providers: [EmptyRouter],
+    }).compile();
+
+    await module.init();
+    const router = module.get(TrpcRouter).getRouter();
+    expect(router._def.procedures).to.deep.equal({});
   });
 
   it('should skip providers with null instance or metatype', async () => {

--- a/packages/trpc/trpc-router.ts
+++ b/packages/trpc/trpc-router.ts
@@ -26,6 +26,33 @@ import { generateSchema, RouterInfo } from './generators/schema-generator';
 import { TrpcModuleOptions, TrpcRouterMetadata } from './interfaces';
 import { trpcRequestStorage } from './trpc-request-storage';
 
+interface RegisteredProcedure {
+  routerClassName: string;
+  methodName: string;
+  procedureName: string;
+  path: string;
+}
+
+interface RouterBuildState {
+  trpc: any;
+  routerMap: Record<string, any>;
+  registeredAliases: Set<string>;
+  namespaceAliases: Set<string>;
+  registeredProcedures: Map<string, RegisteredProcedure>;
+}
+
+interface RouterProviderContext {
+  state: RouterBuildState;
+  wrapper: any;
+  metatype: Type | Function;
+  routerClassName: string;
+  alias: string | undefined;
+  moduleKey: string;
+  procedureMap: Record<string, any>;
+  routerInfo: RouterInfo;
+  prototype: Record<string, any>;
+}
+
 @Injectable()
 export class TrpcRouter<
   TRouter extends AnyRouter = AnyRouter,
@@ -78,158 +105,368 @@ export class TrpcRouter<
   }
 
   private buildRouter(): AnyRouter {
-    const t = initTRPC.context<any>().create();
-    const routerMap: Record<string, any> = {};
+    const state: RouterBuildState = {
+      trpc: initTRPC.context<any>().create(),
+      routerMap: {},
+      registeredAliases: new Set<string>(),
+      namespaceAliases: new Set<string>(),
+      registeredProcedures: new Map<string, RegisteredProcedure>(),
+    };
     this.collectedRouterInfos = [];
 
-    const providers = this.discoveryService.getProviders();
+    for (const wrapper of this.discoveryService.getProviders()) {
+      this.registerRouterProvider(state, wrapper);
+    }
 
-    for (const wrapper of providers) {
-      const { instance, metatype } = wrapper;
-      if (!metatype) {
-        continue;
-      }
+    return state.trpc.router(state.routerMap);
+  }
 
-      const routerMeta: TrpcRouterMetadata | undefined = this.reflector.get(
-        TRPC_ROUTER_METADATA,
-        metatype,
-      );
+  private registerRouterProvider(
+    state: RouterBuildState,
+    wrapper: any,
+  ): void {
+    const context = this.createRouterProviderContext(state, wrapper);
+    if (!context) {
+      return;
+    }
 
-      if (!routerMeta) {
-        continue;
-      }
+    const methodNames = this.metadataScanner.getAllMethodNames(
+      context.prototype,
+    );
+    for (const methodName of methodNames) {
+      this.registerRouterMethod(context, methodName);
+    }
 
-      const alias = routerMeta.alias;
-      const moduleKey = this.resolveModuleKey(metatype);
-      const procedureMap: Record<string, any> = {};
-      const routerInfo: RouterInfo = { alias, procedures: [] };
-      const prototype =
-        instance && typeof instance === 'object'
-          ? Object.getPrototypeOf(instance)
-          : (metatype as Type).prototype;
-      if (!prototype) {
-        continue;
-      }
+    this.commitRouterProvider(context);
+  }
 
-      const methodNames = this.metadataScanner.getAllMethodNames(prototype);
+  private createRouterProviderContext(
+    state: RouterBuildState,
+    wrapper: any,
+  ): RouterProviderContext | undefined {
+    const { instance, metatype } = wrapper;
+    if (!metatype) {
+      return undefined;
+    }
 
-      for (const methodName of methodNames) {
-        const methodRef = prototype[methodName];
-        if (typeof methodRef !== 'function') {
-          continue;
-        }
+    const routerMeta: TrpcRouterMetadata | undefined = this.reflector.get(
+      TRPC_ROUTER_METADATA,
+      metatype,
+    );
+    if (!routerMeta) {
+      return undefined;
+    }
 
-        const procedureName: string | undefined = Reflect.getMetadata(
-          TRPC_PROCEDURE_METADATA,
-          methodRef,
+    const prototype =
+      instance && typeof instance === 'object'
+        ? Object.getPrototypeOf(instance)
+        : (metatype as Type).prototype;
+    if (!prototype) {
+      return undefined;
+    }
+
+    const routerClassName = this.getRouterClassName(metatype);
+    const alias = this.normalizeRouterAlias(routerMeta.alias, routerClassName);
+
+    return {
+      state,
+      wrapper,
+      metatype,
+      routerClassName,
+      alias,
+      moduleKey: this.resolveModuleKey(metatype),
+      procedureMap: {},
+      routerInfo: { alias, procedures: [] },
+      prototype,
+    };
+  }
+
+  private registerRouterMethod(
+    context: RouterProviderContext,
+    methodName: string,
+  ): void {
+    const methodRef = context.prototype[methodName];
+    if (typeof methodRef !== 'function') {
+      return;
+    }
+
+    const procedureName: string | undefined = Reflect.getMetadata(
+      TRPC_PROCEDURE_METADATA,
+      methodRef,
+    );
+    const procedureType: ProcedureType | undefined = Reflect.getMetadata(
+      TRPC_PROCEDURE_TYPE_METADATA,
+      methodRef,
+    );
+
+    if (!procedureName && !procedureType) {
+      return;
+    }
+    this.assertValidProcedureMetadata(
+      context.routerClassName,
+      methodName,
+      procedureName,
+      procedureType,
+    );
+
+    const resolvedProcedureType = procedureType as ProcedureType;
+    const inputSchema = Reflect.getMetadata(TRPC_INPUT_METADATA, methodRef);
+    const outputSchema = Reflect.getMetadata(TRPC_OUTPUT_METADATA, methodRef);
+    const wrappedHandler = this.createWrappedHandler(context, methodName, methodRef);
+
+    this.assertUniqueProcedurePath(
+      context.state.registeredProcedures,
+      {
+        routerClassName: context.routerClassName,
+        methodName,
+        procedureName,
+        path: this.formatProcedurePath(context.alias, procedureName),
+      },
+    );
+
+    context.procedureMap[procedureName] = this.createProcedure(
+      context.state.trpc.procedure,
+      resolvedProcedureType,
+      inputSchema,
+      outputSchema,
+      wrappedHandler,
+    );
+
+    this.logger.log(
+      `Mapped {${resolvedProcedureType}} "${context.alias ? context.alias + '.' : ''}${procedureName}" procedure`,
+    );
+
+    context.routerInfo.procedures.push({
+      name: procedureName,
+      type: resolvedProcedureType,
+      inputSchema,
+      outputSchema,
+    });
+  }
+
+  private createWrappedHandler(
+    context: RouterProviderContext,
+    methodName: string,
+    methodRef: (...args: any[]) => any,
+  ): (input: unknown, ctx: unknown) => Promise<unknown> {
+    const paramTypes: unknown[] =
+      Reflect.getMetadata(PARAMTYPES_METADATA, context.prototype, methodName) ??
+      [];
+
+    return this.contextCreator.create({
+      callback: methodRef,
+      methodName,
+      moduleKey: context.moduleKey,
+      paramTypes,
+      inquirerId: context.wrapper.id,
+      resolveContextId: () => this.resolveContextId(context.wrapper),
+      resolveInstance: (contextId: { id: number }) =>
+        this.resolveRouterInstance(context.wrapper, context.metatype, contextId),
+    });
+  }
+
+  private createProcedure(
+    baseProcedure: any,
+    procedureType: ProcedureType,
+    inputSchema: any,
+    outputSchema: any,
+    wrappedHandler: (input: unknown, ctx: unknown) => Promise<unknown>,
+  ): any {
+    let procedure = baseProcedure;
+
+    if (inputSchema) {
+      procedure = procedure.input(inputSchema) as any;
+    }
+    if (outputSchema && procedureType !== ProcedureType.SUBSCRIPTION) {
+      procedure = procedure.output(outputSchema) as any;
+    }
+
+    switch (procedureType) {
+      case ProcedureType.QUERY:
+        return procedure.query(
+          async ({ input, ctx }: { input: unknown; ctx: unknown }) => {
+            return wrappedHandler(input, ctx);
+          },
         );
-        const procedureType: ProcedureType | undefined = Reflect.getMetadata(
-          TRPC_PROCEDURE_TYPE_METADATA,
-          methodRef,
+      case ProcedureType.MUTATION:
+        return procedure.mutation(
+          async ({ input, ctx }: { input: unknown; ctx: unknown }) => {
+            return wrappedHandler(input, ctx);
+          },
         );
-
-        if (!procedureName || !procedureType) {
-          continue;
-        }
-
-        const inputSchema = Reflect.getMetadata(TRPC_INPUT_METADATA, methodRef);
-        const outputSchema = Reflect.getMetadata(
-          TRPC_OUTPUT_METADATA,
-          methodRef,
-        );
-
-        let procedure = t.procedure;
-
-        if (inputSchema) {
-          procedure = procedure.input(inputSchema) as any;
-        }
-        if (outputSchema && procedureType !== ProcedureType.SUBSCRIPTION) {
-          procedure = procedure.output(outputSchema) as any;
-        }
-
-        const paramTypes: unknown[] =
-          Reflect.getMetadata(PARAMTYPES_METADATA, prototype, methodName) ?? [];
-
-        // Create a context-aware handler that runs guards → interceptors → pipes → handler,
-        // including request-scoped providers and filters.
-        const wrappedHandler = this.contextCreator.create({
-          callback: methodRef,
-          methodName,
-          moduleKey,
-          paramTypes,
-          inquirerId: wrapper.id,
-          resolveContextId: () => this.resolveContextId(wrapper),
-          resolveInstance: (contextId: { id: number }) =>
-            this.resolveRouterInstance(wrapper, metatype, contextId),
-        });
-
-        switch (procedureType) {
-          case ProcedureType.QUERY:
-            procedureMap[procedureName] = procedure.query(
-              async ({ input, ctx }: { input: unknown; ctx: unknown }) => {
-                return wrappedHandler(input, ctx);
-              },
-            );
-            break;
-          case ProcedureType.MUTATION:
-            procedureMap[procedureName] = procedure.mutation(
-              async ({ input, ctx }: { input: unknown; ctx: unknown }) => {
-                return wrappedHandler(input, ctx);
-              },
-            );
-            break;
-          case ProcedureType.SUBSCRIPTION: {
-            const validateOutput = (value: unknown) =>
-              this.validateSubscriptionOutput(outputSchema, value);
-            procedureMap[procedureName] = procedure.subscription(
-              async function* ({
-                input,
-                ctx,
-              }: {
-                input: unknown;
-                ctx: unknown;
-              }) {
-                const result = await wrappedHandler(input, ctx);
-                if (
-                  result != null &&
-                  typeof result === 'object' &&
-                  Symbol.asyncIterator in (result as any)
-                ) {
-                  for await (const chunk of result as AsyncIterable<unknown>) {
-                    yield await validateOutput(chunk);
-                  }
-                } else {
-                  yield await validateOutput(result);
-                }
-              },
-            );
-            break;
-          }
-        }
-
-        this.logger.log(
-          `Mapped {${procedureType}} "${alias ? alias + '.' : ''}${procedureName}" procedure`,
-        );
-
-        routerInfo.procedures.push({
-          name: procedureName,
-          type: procedureType,
-          inputSchema,
+      case ProcedureType.SUBSCRIPTION:
+        return this.createSubscriptionProcedure(
+          procedure,
           outputSchema,
-        });
-      }
+          wrappedHandler,
+        );
+    }
+  }
 
-      if (Object.keys(procedureMap).length > 0) {
-        if (alias) {
-          this.assignAliasedRouter(routerMap, alias, t.router(procedureMap));
+  private createSubscriptionProcedure(
+    procedure: any,
+    outputSchema: any,
+    wrappedHandler: (input: unknown, ctx: unknown) => Promise<unknown>,
+  ): any {
+    const validateOutput = (value: unknown) =>
+      this.validateSubscriptionOutput(outputSchema, value);
+
+    return procedure.subscription(
+      async function* ({
+        input,
+        ctx,
+      }: {
+        input: unknown;
+        ctx: unknown;
+      }) {
+        const result = await wrappedHandler(input, ctx);
+        if (
+          result != null &&
+          typeof result === 'object' &&
+          Symbol.asyncIterator in (result as any)
+        ) {
+          for await (const chunk of result as AsyncIterable<unknown>) {
+            yield await validateOutput(chunk);
+          }
         } else {
-          Object.assign(routerMap, procedureMap);
+          yield await validateOutput(result);
         }
-        this.collectedRouterInfos.push(routerInfo);
+      },
+    );
+  }
+
+  private commitRouterProvider(context: RouterProviderContext): void {
+    if (Object.keys(context.procedureMap).length === 0) {
+      return;
+    }
+
+    if (context.alias) {
+      this.assertUniqueAliasPath(
+        context.alias,
+        context.routerClassName,
+        context.state.registeredAliases,
+        context.state.namespaceAliases,
+      );
+      this.assignAliasedRouter(
+        context.state.routerMap,
+        context.alias,
+        context.state.trpc.router(context.procedureMap),
+      );
+    } else {
+      Object.assign(context.state.routerMap, context.procedureMap);
+    }
+
+    this.collectedRouterInfos.push(context.routerInfo);
+  }
+
+  private getRouterClassName(metatype: Type | Function): string {
+    return metatype.name;
+  }
+
+  private normalizeRouterAlias(
+    alias: string | undefined,
+    routerClassName: string,
+  ): string | undefined {
+    if (alias === undefined) {
+      return undefined;
+    }
+
+    const segments = alias
+      .split('.')
+      .map(segment => segment.trim());
+
+    if (segments.some(segment => segment.length === 0)) {
+      throw this.createConfigurationError(
+        `Invalid tRPC router alias "${alias}" on ${routerClassName}.`,
+        'Use @Router() for a root router, or provide a non-empty dotted alias such as @Router("users") or @Router("admin.users").',
+      );
+    }
+
+    return segments.join('.');
+  }
+
+  private assertValidProcedureMetadata(
+    routerClassName: string,
+    methodName: string,
+    procedureName: string | undefined,
+    procedureType: ProcedureType | undefined,
+  ): asserts procedureName is string {
+    if (!procedureName || procedureName.trim().length === 0) {
+      throw this.createConfigurationError(
+        `Invalid tRPC procedure name on ${routerClassName}.${methodName}.`,
+        'Pass a non-empty name to @Query(), @Mutation(), or @Subscription(), or omit the name to use the method name.',
+      );
+    }
+
+    if (!procedureType) {
+      throw this.createConfigurationError(
+        `Invalid tRPC procedure metadata on ${routerClassName}.${methodName} for procedure "${procedureName}".`,
+        'Apply exactly one procedure decorator: @Query(), @Mutation(), or @Subscription().',
+      );
+    }
+  }
+
+  private formatProcedurePath(
+    alias: string | undefined,
+    procedureName: string,
+  ): string {
+    return alias ? `${alias}.${procedureName}` : procedureName;
+  }
+
+  private assertUniqueProcedurePath(
+    registeredProcedures: Map<string, RegisteredProcedure>,
+    candidate: RegisteredProcedure,
+  ): void {
+    const existing = registeredProcedures.get(candidate.path);
+    if (existing) {
+      throw this.createConfigurationError(
+        `Duplicate tRPC procedure path "${candidate.path}" discovered in ${candidate.routerClassName}.${candidate.methodName}.`,
+        `It was already registered by ${existing.routerClassName}.${existing.methodName}. Rename one procedure with @Query("name"), @Mutation("name"), or @Subscription("name"), or change one router alias.`,
+      );
+    }
+
+    registeredProcedures.set(candidate.path, candidate);
+  }
+
+  private assertUniqueAliasPath(
+    alias: string,
+    routerClassName: string,
+    registeredAliases: Set<string>,
+    namespaceAliases: Set<string>,
+  ): void {
+    if (registeredAliases.has(alias)) {
+      throw this.createConfigurationError(
+        `Duplicate tRPC router alias "${alias}" discovered on ${routerClassName}.`,
+        'Use a unique router alias, or merge the procedures into a single router class.',
+      );
+    }
+
+    const segments = alias.split('.');
+    for (let index = 1; index < segments.length; index += 1) {
+      const prefix = segments.slice(0, index).join('.');
+      if (registeredAliases.has(prefix)) {
+        throw this.createConfigurationError(
+          `Conflicting tRPC router alias "${alias}" discovered on ${routerClassName}.`,
+          `The alias "${prefix}" is already registered as a router. Rename one alias so a path segment is not both a router and a namespace.`,
+        );
       }
     }
 
-    return t.router(routerMap);
+    if (namespaceAliases.has(alias)) {
+      throw this.createConfigurationError(
+        `Conflicting tRPC router alias "${alias}" discovered on ${routerClassName}.`,
+        'That alias is already used as a namespace for another router. Rename one alias so a path segment is not both a router and a namespace.',
+      );
+    }
+
+    registeredAliases.add(alias);
+    for (let index = 1; index < segments.length; index += 1) {
+      namespaceAliases.add(segments.slice(0, index).join('.'));
+    }
+  }
+
+  private createConfigurationError(message: string, suggestion: string): Error {
+    return new Error(`${message} Suggested fix: ${suggestion}`);
   }
 
   private assignAliasedRouter(
@@ -241,10 +478,6 @@ export class TrpcRouter<
       .split('.')
       .map(segment => segment.trim())
       .filter(Boolean);
-
-    if (segments.length === 0) {
-      return;
-    }
 
     let cursor: Record<string, any> = routerMap;
 

--- a/website/docs/reference/claims-matrix.md
+++ b/website/docs/reference/claims-matrix.md
@@ -17,6 +17,7 @@ This page maps the main public claims to current verification evidence. It is a 
 | `@TrpcContext()` supports full context and field extraction. | `packages/trpc/test/context/trpc-context-creator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/03-context-request-scope` | Covered by package tests and samples. |
 | `autoSchemaFile` generates importable `AppRouter` types. | `packages/trpc/test/generators/schema-generator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/08-autoschema-client-typecheck/src/client.typecheck.ts` | Covered by package tests and client typecheck sample. |
 | `TrpcRouter` is supported for in-process testing. | `website/docs/testing/router-testing.md`, `packages/trpc/test/router/trpc-router.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts` | Covered as advanced testing API. |
+| Invalid router aliases and duplicate procedure paths fail with actionable diagnostics. | `packages/trpc/test/router/trpc-router.spec.ts` | Covered by package tests. |
 
 ## NestJS Integration Claims
 
@@ -54,7 +55,6 @@ This page maps the main public claims to current verification evidence. It is a 
 
 These gaps should guide future PRs:
 
-- Add a dedicated duplicate-router/procedure-name validation test once runtime diagnostics are improved.
 - Add golden tests for generated schema formatting if output formatting becomes part of the release claim.
 - Keep benchmark claims out of README and docs until a reproducible benchmark harness exists. See [Benchmark Methodology](../advanced/benchmark-methodology).
 


### PR DESCRIPTION
## Summary

Adds early, actionable diagnostics for invalid router and procedure configuration while reducing the router builder's cognitive complexity.

## Changes

- Rejects empty or malformed router aliases with a suggested fix.
- Rejects duplicate procedure paths across root and aliased routers.
- Rejects duplicate router aliases and alias namespace collisions.
- Rejects empty custom procedure names and incomplete procedure metadata.
- Refactors router building into smaller helper methods so trpc-router.ts max cognitive complexity drops to 7.
- Adds a generated schema formatting golden test.
- Updates the claims matrix to mark diagnostics coverage as package-tested.

## Validation

- git diff --check
- npm run build --workspace nest-trpc-native
- npm run typecheck --workspace nest-trpc-native
- npm run test:cov
- npm run docs:test:typecheck
- npm run complexity:report

## Notes

- No dependency changes.
- Complexity report after this change: project max 12, trpc-router.ts max 7.