### PR TITLE
Configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      dev-tooling-minor-patch:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+      nest-trpc-peer-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "@nestjs/common"
+          - "@nestjs/config"
+          - "@nestjs/core"
+          - "@nestjs/microservices"
+          - "@nestjs/platform-express"
+          - "@nestjs/platform-fastify"
+          - "@trpc/*"
+          - "reflect-metadata"
+          - "rxjs"
+          - "zod"
+
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
+      include: "scope"
+    groups:
+      docusaurus-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "@docusaurus/*"
+      website-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "@docusaurus/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(actions)"
+      include: "scope"

--- a/AI_CODING_GUIDELINES.md
+++ b/AI_CODING_GUIDELINES.md
@@ -97,6 +97,11 @@ This is not a suggestion — it is the project constitution.
   - Flag unpinned Git/URL dependencies unless there is explicit, documented approval.
   - Inspect install/lifecycle scripts (`preinstall`, `install`, `postinstall`, `prepare`) for malicious behavior risk.
   - Watch for typosquatting, suspicious package ownership changes, abandoned packages, and sudden lockfile churn.
+  - Treat Dependabot PRs as automation assistance, not approval to merge:
+    - Keep major updates isolated unless a maintainer explicitly requests grouping.
+    - Verify `packages/trpc/package.json` still has `"dependencies": {}` after every dependency PR.
+    - Run the same validation expected for a human-authored dependency update.
+    - Do not auto-accept lockfile churn without understanding which direct dependency caused it.
 - Application security checks are required in PR reviews:
   - Auth/authz bypass risk, privilege escalation, and data exposure in handlers, decorators, and context wiring.
   - Input-validation gaps and injection surfaces (command/template/SQL-like patterns, prototype pollution, path traversal).


### PR DESCRIPTION

## Summary
- add Dependabot version-update configuration for the root npm workspace, website npm project, and GitHub Actions
- group minor/patch dependency updates to reduce PR noise while leaving major updates separate for review
- add AI coding guidance for reviewing Dependabot PRs as supply-chain changes, not automatic approvals

## Notes
- Root npm updates cover the workspace package graph and samples.
- Website updates are configured separately because the Docusaurus site has its own package-lock.json.
- Major dependency updates are intentionally not grouped so they get focused review.

## Validation
- parsed .github/dependabot.yml with js-yaml
- git diff --cached --check
