### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.4.0
+
+Production-readiness release focused on documentation, verification, and release confidence:
+
+- add contributor, security, issue, and pull request workflows
+- publish a Docusaurus documentation site with support policy, public API tiers, claims matrix, samples, testing, production, and benchmark methodology guidance
+- refresh README and package discovery content around supported Node, NestJS, tRPC, Zod, samples, and zero-runtime-dependency expectations
+- add real `@trpc/client` E2E coverage for Express and Fastify adapters
+- split CI into focused package, coverage, docs, Docusaurus, release, showcase, and sample jobs across Node 20 and Node 22 where relevant
+- add release checks for README links, sample version synchronization, workspace resolution, and package tarball contents
+- enforce SonarJS cognitive complexity for package source functions and publish cognitive complexity PR reports
+- update the test runner to support Chai 6's ESM-only package
+- add Dependabot automation for npm workspaces, website dependencies, and GitHub Actions updates
+
 ## 0.3.1
 
 - standardize Zod support on `4.x` as the supported optional peer dependency

--- a/package-lock.json
+++ b/package-lock.json
@@ -8291,7 +8291,7 @@
     },
     "packages/trpc": {
       "name": "nest-trpc-native",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.1.19",
@@ -8333,7 +8333,7 @@
         "class-validator": "0.15.1",
         "eventsource": "4.1.0",
         "fastify": "5.8.5",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2",
@@ -8802,7 +8802,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8823,7 +8823,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8844,7 +8844,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8865,7 +8865,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2",
@@ -8889,7 +8889,7 @@
         "@trpc/server": "^11.16.0",
         "class-transformer": "0.5.1",
         "class-validator": "0.15.1",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8911,7 +8911,7 @@
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
         "eventsource": "4.1.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8934,7 +8934,7 @@
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
         "fastify": "5.8.5",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -8988,7 +8988,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -9010,7 +9010,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -9031,7 +9031,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -9053,7 +9053,7 @@
         "@nestjs/platform-express": "11.1.19",
         "@trpc/client": "^11.16.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.3.1",
+        "nest-trpc-native": "0.4.0",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-trpc-native",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Decorator-first tRPC integration bridge for NestJS",
   "keywords": [
     "nestjs",

--- a/sample/00-showcase/package.json
+++ b/sample/00-showcase/package.json
@@ -31,7 +31,7 @@
     "class-validator": "0.15.1",
     "eventsource": "4.1.0",
     "fastify": "5.8.5",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/01-basics-query-mutation/package.json
+++ b/sample/01-basics-query-mutation/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/02-enhancers-guards-pipes-filters/package.json
+++ b/sample/02-enhancers-guards-pipes-filters/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/03-context-request-scope/package.json
+++ b/sample/03-context-request-scope/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/04-validation-zod/package.json
+++ b/sample/04-validation-zod/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/05-validation-class-validator/package.json
+++ b/sample/05-validation-class-validator/package.json
@@ -20,7 +20,7 @@
     "@trpc/server": "^11.16.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/06-subscriptions/package.json
+++ b/sample/06-subscriptions/package.json
@@ -21,7 +21,7 @@
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
     "eventsource": "4.1.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/07-express-fastify/package.json
+++ b/sample/07-express-fastify/package.json
@@ -22,7 +22,7 @@
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
     "fastify": "5.8.5",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/08-autoschema-client-typecheck/package.json
+++ b/sample/08-autoschema-client-typecheck/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/09-forrootasync-config-middleware/package.json
+++ b/sample/09-forrootasync-config-middleware/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/10-nested-alias-routers/package.json
+++ b/sample/10-nested-alias-routers/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/11-microservice-transport/package.json
+++ b/sample/11-microservice-transport/package.json
@@ -20,7 +20,7 @@
     "@nestjs/platform-express": "11.1.19",
     "@trpc/client": "^11.16.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.3.1",
+    "nest-trpc-native": "0.4.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"


### PR DESCRIPTION

## Summary
- bump nest-trpc-native to 0.4.0
- align every sample workspace dependency on nest-trpc-native@0.4.0
- regenerate package-lock.json after version alignment
- add the 0.4.0 changelog entry

## Release checks
- npm view nest-trpc-native@0.4.0 version reports the version is not published yet
- npm install
- npm run release:check
- npm ls nest-trpc-native --workspaces --depth=0
- npm audit --workspace nest-trpc-native --omit=dev --json
- npm outdated --json
- npm run ci
- git diff --check

## Security
- packages/trpc/package.json keeps the explicit empty runtime dependencies block
- published package workspace production audit reports zero vulnerabilities
- no new dependencies were added
