### PR TITLE
chore: update npm package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,5 +95,5 @@
     "statements": 100,
     "cache": false
   },
-  "packageManager": "npm@10.9.7"
+  "packageManager": "npm@11.13.0"
 }


### PR DESCRIPTION
## Summary
- update the repository packageManager pin from npm 10.9.7 to npm 11.13.0
- keep package-lock.json unchanged for this tooling-only PR

## Validation
- npx --yes npm@11.13.0 run test
- npx --yes npm@11.13.0 run release:check

## Security / supply-chain
- npm@11.13.0 is the current npm package-manager release checked from the npm registry
- package-lock.json is intentionally unchanged for the tooling-only scope
- packages/trpc/package.json still has an explicit empty dependencies block
