### PR TITLE
chore: migrate repository to nest-native org

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage
 complexity
 .tmp
 GUIDELINES_NEST_TRPC.md
+todo-*.txt

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <a href="https://www.npmjs.com/package/nest-trpc-native"><img src="https://img.shields.io/npm/dm/nest-trpc-native.svg" alt="NPM Downloads" /></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="Package License" /></a>
   <img src="https://img.shields.io/badge/coverage-100%25-brightgreen.svg" alt="Test Coverage" />
-  <a href="https://rodrigobnogueira.github.io/nest-trpc-native/"><img src="https://img.shields.io/badge/docs-nest--trpc--native-e0234e.svg" alt="Documentation" /></a>
+  <a href="https://nest-native.github.io/nest-trpc-native/"><img src="https://img.shields.io/badge/docs-nest--trpc--native-e0234e.svg" alt="Documentation" /></a>
 </p>
 
 ## What This Is
@@ -14,10 +14,10 @@
 
 The documentation site is the canonical source of truth for usage guides and support policy:
 
-- [Introduction](https://rodrigobnogueira.github.io/nest-trpc-native/docs/introduction)
-- [Quick Start](https://rodrigobnogueira.github.io/nest-trpc-native/docs/quick-start)
-- [Samples](https://rodrigobnogueira.github.io/nest-trpc-native/docs/samples)
-- [Support Policy](https://rodrigobnogueira.github.io/nest-trpc-native/docs/support-policy)
+- [Introduction](https://nest-native.github.io/nest-trpc-native/docs/introduction)
+- [Quick Start](https://nest-native.github.io/nest-trpc-native/docs/quick-start)
+- [Samples](https://nest-native.github.io/nest-trpc-native/docs/samples)
+- [Support Policy](https://nest-native.github.io/nest-trpc-native/docs/support-policy)
 
 ## Why Use It
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "description": "Community standalone monorepo for nest-trpc-native and samples",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nest-native/nest-trpc-native.git"
+  },
   "license": "MIT",
   "workspaces": [
     "packages/*",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -18,10 +18,10 @@
   ],
   "author": "Rodrigo Nogueira",
   "license": "MIT",
-  "homepage": "https://github.com/rodrigobnogueira/nest-trpc-native#readme",
+  "homepage": "https://github.com/nest-native/nest-trpc-native#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rodrigobnogueira/nest-trpc-native.git",
+    "url": "git+https://github.com/nest-native/nest-trpc-native.git",
     "directory": "packages/trpc"
   },
   "main": "./dist/index.js",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -11,10 +11,10 @@ const config: Config = {
     v4: true,
   },
 
-  url: 'https://rodrigobnogueira.github.io',
+  url: 'https://nest-native.github.io',
   baseUrl: '/nest-trpc-native/',
 
-  organizationName: 'rodrigobnogueira',
+  organizationName: 'nest-native',
   projectName: 'nest-trpc-native',
 
   onBrokenLinks: 'throw',
@@ -31,7 +31,7 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           editUrl:
-            'https://github.com/rodrigobnogueira/nest-trpc-native/tree/main/website/',
+            'https://github.com/nest-native/nest-trpc-native/tree/main/website/',
         },
         blog: false,
         theme: {
@@ -61,7 +61,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://github.com/rodrigobnogueira/nest-trpc-native',
+          href: 'https://github.com/nest-native/nest-trpc-native',
           label: 'GitHub',
           position: 'right',
         },
@@ -83,7 +83,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/rodrigobnogueira/nest-trpc-native',
+              href: 'https://github.com/nest-native/nest-trpc-native',
             },
             {
               label: 'npm',


### PR DESCRIPTION
Updates repository links, documentation URLs, and GitHub references from rodrigobnogueira to nest-native organization.