### PR TITLE
release v0.4.3 — fix HttpException mapping with interceptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- fix: preserve `HttpException` → tRPC error mapping when an interceptor is in the chain (e.g. `ClsModule`'s default passthrough `APP_INTERCEPTOR`). Previously, any `HttpException` thrown inside a procedure was silently coerced to `INTERNAL_SERVER_ERROR`/500 because the result of `transformToResult` was returned without `await`, letting deferred-Observable rejections escape the surrounding try/catch.
+
 ## 0.4.0
 
 Production-readiness release focused on documentation, verification, and release confidence:

--- a/packages/trpc/context/trpc-context-creator.ts
+++ b/packages/trpc/context/trpc-context-creator.ts
@@ -335,7 +335,12 @@ export class TrpcContextCreator {
               )
             : await handler();
 
-        return this.transformToResult(result);
+        // `return await` is required (not just `return`): when an interceptor
+        // returns a deferred Observable, `transformToResult` yields a Promise
+        // that may reject after subscription. Without `await`, the rejection
+        // escapes this try/catch and HttpExceptions are mis-mapped to
+        // INTERNAL_SERVER_ERROR by the @trpc/server boundary.
+        return await this.transformToResult(result);
       } catch (error) {
         return this.handleException(error, exceptionHandler, executionContext);
       }

--- a/packages/trpc/test/context/trpc-context-creator.spec.ts
+++ b/packages/trpc/test/context/trpc-context-creator.spec.ts
@@ -1,7 +1,14 @@
-import { BadRequestException, HttpException, HttpStatus } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  HttpException,
+  HttpStatus,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { expect } from 'chai';
 import 'reflect-metadata';
-import { of } from 'rxjs';
+import { defer, of } from 'rxjs';
 import * as sinon from 'sinon';
 import { TRPCError } from '@trpc/server';
 import { TRPC_PARAM_ARGS_METADATA } from '../../constants';
@@ -445,5 +452,125 @@ describe('TrpcContextCreator (unit)', () => {
     expect(error).to.be.instanceOf(TRPCError);
     expect((error as TRPCError).code).to.equal('INTERNAL_SERVER_ERROR');
     expect((error as TRPCError).message).to.include('teapot');
+  });
+
+  /**
+   * Regression: when an interceptor is present in the chain (e.g. ClsModule's
+   * default passthrough APP_INTERCEPTOR), an HttpException thrown by the
+   * handler used to be silently coerced to INTERNAL_SERVER_ERROR because
+   * `return this.transformToResult(result)` was not awaited inside the
+   * try/catch — the rejected Promise escaped past `handleException` and the
+   * @trpc/server boundary wrapped it as a generic 500.
+   *
+   * The interceptor must subscribe to a deferred Observable (mirroring real
+   * `InterceptorsConsumer.intercept` semantics) for the bug to manifest;
+   * a previous test (`should handle interceptors that return observables`)
+   * awaits `next()` eagerly and therefore does not exercise the bug.
+   */
+  describe('HttpException through interceptor chain (regression)', () => {
+    const createCreatorWithDeferredInterceptor = () => {
+      const interceptorCreator = {
+        create: sinon.stub().returns([{}]),
+      };
+      const interceptorConsumer = {
+        intercept: sinon
+          .stub()
+          .callsFake(
+            async (
+              _interceptors: any,
+              _args: any,
+              _instance: any,
+              _callback: any,
+              next: () => Promise<unknown>,
+            ) => {
+              // Mirror real Nest InterceptorsConsumer: return an Observable
+              // that defers the handler invocation until subscription.
+              return defer(() => next());
+            },
+          ),
+      };
+
+      return new TrpcContextCreator(
+        { create: sinon.stub().returns([]) } as any,
+        { tryActivate: sinon.stub().resolves(true) } as any,
+        interceptorCreator as any,
+        interceptorConsumer as any,
+        { create: sinon.stub().returns([]) } as any,
+        {} as any,
+        createExceptionFiltersContextStub() as any,
+      );
+    };
+
+    const captureError = async (
+      wrapped: (input: unknown, ctx: unknown) => Promise<unknown>,
+    ): Promise<unknown> => {
+      try {
+        await wrapped({}, {});
+        return undefined;
+      } catch (err) {
+        return err;
+      }
+    };
+
+    it('should map UnauthorizedException to UNAUTHORIZED through interceptors', async () => {
+      const handler = sinon.stub().throws(new UnauthorizedException('nope'));
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const error = await captureError(wrapped);
+      expect(error).to.be.instanceOf(TRPCError);
+      expect((error as TRPCError).code).to.equal('UNAUTHORIZED');
+      expect((error as TRPCError).message).to.include('nope');
+    });
+
+    it('should map NotFoundException to NOT_FOUND through interceptors', async () => {
+      const handler = sinon.stub().throws(new NotFoundException('absent'));
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const error = await captureError(wrapped);
+      expect(error).to.be.instanceOf(TRPCError);
+      expect((error as TRPCError).code).to.equal('NOT_FOUND');
+    });
+
+    it('should map ForbiddenException to FORBIDDEN through interceptors', async () => {
+      const handler = sinon.stub().throws(new ForbiddenException('denied'));
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const error = await captureError(wrapped);
+      expect(error).to.be.instanceOf(TRPCError);
+      expect((error as TRPCError).code).to.equal('FORBIDDEN');
+    });
+
+    it('should map BadRequestException to BAD_REQUEST through interceptors', async () => {
+      const handler = sinon.stub().throws(new BadRequestException('invalid'));
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const error = await captureError(wrapped);
+      expect(error).to.be.instanceOf(TRPCError);
+      expect((error as TRPCError).code).to.equal('BAD_REQUEST');
+    });
+
+    it('should still map plain Error to INTERNAL_SERVER_ERROR through interceptors', async () => {
+      const handler = sinon.stub().throws(new Error('boom'));
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const error = await captureError(wrapped);
+      expect(error).to.be.instanceOf(TRPCError);
+      expect((error as TRPCError).code).to.equal('INTERNAL_SERVER_ERROR');
+      expect((error as TRPCError).message).to.equal('boom');
+    });
+
+    it('should resolve normally through a deferred interceptor when handler succeeds', async () => {
+      const handler = sinon.stub().returns('ok');
+      const creator = createCreatorWithDeferredInterceptor();
+      const wrapped = creator.create({ handler } as any, handler, '');
+
+      const result = await wrapped({}, {});
+      expect(result).to.equal('ok');
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: With any `APP_INTERCEPTOR` registered (notably `nestjs-cls`'s default passthrough), every `HttpException` thrown inside a tRPC procedure was silently coerced to `INTERNAL_SERVER_ERROR`/500. `UnauthorizedException`, `NotFoundException`, `BadRequestException`, `ForbiddenException`, etc. all lost their status semantics on the wire, breaking client-side error branching and flooding logs with false 500s.
- **Fix**: one-line — add `await` to `return this.transformToResult(result)` inside `createHandler`'s `try` block in [`packages/trpc/context/trpc-context-creator.ts`](packages/trpc/context/trpc-context-creator.ts).
- **Tests**: 6 new regression tests in [`packages/trpc/test/context/trpc-context-creator.spec.ts`](packages/trpc/test/context/trpc-context-creator.spec.ts) exercising `UnauthorizedException`, `NotFoundException`, `ForbiddenException`, `BadRequestException`, plain `Error`, and the success path — all through a deferred-Observable interceptor that mirrors real Nest `InterceptorsConsumer.intercept` semantics. 5/6 fail on `main` before the fix, all 6 green after.

## Root cause

`InterceptorsConsumer.intercept(...)` returns an Observable that defers handler invocation until subscription. `transformToResult` then calls `lastValueFrom(observable)`, yielding a Promise that rejects when the handler throws. The previous `return this.transformToResult(result)` (no `await`) inside `try { ... }` is the well-known async-function antipattern — the rejection bypasses the surrounding `catch` and escapes past `handleException` → `toTrpcError`, so the `@trpc/server` boundary wraps the raw error as a generic 500.

The bug only manifests when `interceptors.length > 0`. A vanilla app without any registered interceptors hits the `await handler()` branch directly and is unaffected — which is why this slipped through existing coverage.

## Test plan

- [x] Failing regression tests added first (TDD) and confirmed red on `main`
- [x] One-line fix applied
- [x] All 6 new tests green
- [x] Full suite: **179 passing**, zero regressions (`npm test`)
- [x] `npm run complexity:check` clean
- [x] `npm run typecheck` clean
- [x] CHANGELOG `[Unreleased]` entry added

## Interaction with `nestjs-cls`

`ClsModule.forRoot()` unconditionally registers an `APP_INTERCEPTOR` (passthrough by default when `interceptor.mount: false`). That passthrough still counts as an interceptor in the chain, so `interceptors.length >= 1` for every procedure in any app using `nestjs-cls` — making this bug fire on every error in every production NestJS + tRPC + CLS deployment. High-severity for anyone combining the libraries.