### PR TITLE
chore: release v0.4.3 — sync version bumps to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## 0.4.3
 
 - fix: preserve `HttpException` → tRPC error mapping when an interceptor is in the chain (e.g. `ClsModule`'s default passthrough `APP_INTERCEPTOR`). Previously, any `HttpException` thrown inside a procedure was silently coerced to `INTERNAL_SERVER_ERROR`/500 because the result of `transformToResult` was returned without `await`, letting deferred-Observable rejections escape the surrounding try/catch.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3225,9 +3225,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3245,9 +3242,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3265,9 +3259,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3285,9 +3276,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3305,9 +3293,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3325,9 +3310,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3345,9 +3327,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4079,9 +4058,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4103,9 +4079,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4127,9 +4100,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4151,9 +4121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4175,9 +4142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4199,9 +4163,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4396,9 +4357,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4416,9 +4374,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4436,9 +4391,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4456,9 +4408,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4635,9 +4584,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4652,9 +4598,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4669,9 +4612,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4686,9 +4626,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4703,9 +4640,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4720,9 +4654,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4737,9 +4668,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4754,9 +4682,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4771,9 +4696,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4788,9 +4710,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4805,9 +4724,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4822,9 +4738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4839,9 +4752,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13777,7 +13687,7 @@
     },
     "packages/trpc": {
       "name": "nest-trpc-native",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.1.21",
@@ -13852,7 +13762,7 @@
         "class-validator": "0.15.1",
         "eventsource": "4.1.0",
         "fastify": "5.8.5",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2",
@@ -13994,7 +13904,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14046,7 +13956,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14098,7 +14008,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14150,7 +14060,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2",
@@ -14205,7 +14115,7 @@
         "@trpc/server": "^11.16.0",
         "class-transformer": "0.5.1",
         "class-validator": "0.15.1",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14258,7 +14168,7 @@
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
         "eventsource": "4.1.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14312,7 +14222,7 @@
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
         "fastify": "5.8.5",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14364,7 +14274,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14417,7 +14327,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14469,7 +14379,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14522,7 +14432,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rimraf": "6.1.3",
         "rxjs": "7.8.2"
@@ -14578,7 +14488,7 @@
         "@nestjs/platform-express": "11.1.21",
         "@trpc/client": "^11.17.0",
         "@trpc/server": "^11.16.0",
-        "nest-trpc-native": "0.4.2",
+        "nest-trpc-native": "0.4.3",
         "reflect-metadata": "0.2.2",
         "rxjs": "7.8.2",
         "tslib": "2.8.1",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nest-trpc-native",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Decorator-first tRPC integration bridge for NestJS",
   "keywords": [
     "nestjs",

--- a/sample/00-showcase/package.json
+++ b/sample/00-showcase/package.json
@@ -31,7 +31,7 @@
     "class-validator": "0.15.1",
     "eventsource": "4.1.0",
     "fastify": "5.8.5",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/01-basics-query-mutation/package.json
+++ b/sample/01-basics-query-mutation/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/02-enhancers-guards-pipes-filters/package.json
+++ b/sample/02-enhancers-guards-pipes-filters/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/03-context-request-scope/package.json
+++ b/sample/03-context-request-scope/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/04-validation-zod/package.json
+++ b/sample/04-validation-zod/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/05-validation-class-validator/package.json
+++ b/sample/05-validation-class-validator/package.json
@@ -20,7 +20,7 @@
     "@trpc/server": "^11.16.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.15.1",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/06-subscriptions/package.json
+++ b/sample/06-subscriptions/package.json
@@ -21,7 +21,7 @@
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
     "eventsource": "4.1.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/07-express-fastify/package.json
+++ b/sample/07-express-fastify/package.json
@@ -22,7 +22,7 @@
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
     "fastify": "5.8.5",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/08-autoschema-client-typecheck/package.json
+++ b/sample/08-autoschema-client-typecheck/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/09-forrootasync-config-middleware/package.json
+++ b/sample/09-forrootasync-config-middleware/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/10-nested-alias-routers/package.json
+++ b/sample/10-nested-alias-routers/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/11-microservice-transport/package.json
+++ b/sample/11-microservice-transport/package.json
@@ -20,7 +20,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/12-angular-fullstack-showcase/package.json
+++ b/sample/12-angular-fullstack-showcase/package.json
@@ -32,7 +32,7 @@
     "@nestjs/platform-express": "11.1.21",
     "@trpc/client": "^11.17.0",
     "@trpc/server": "^11.16.0",
-    "nest-trpc-native": "0.4.2",
+    "nest-trpc-native": "0.4.3",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",


### PR DESCRIPTION
## Summary

**0.4.3 is already published to npm** (`npm view nest-trpc-native@0.4.3` confirms), but the `chore: release v0.4.3` version-bump commit didn't make it into main when #72 was merged — only the fix-commit (`8e98209`) was merged.

This PR cherry-picks the missing commit (originally `9204dae` from the #72 branch) so main reflects what's on the registry.

## State after merge

- [packages/trpc/package.json](packages/trpc/package.json): `0.4.2` → `0.4.3`
- All 13 [sample/*/package.json](sample) `nest-trpc-native` deps: `0.4.2` → `0.4.3`
- [CHANGELOG.md](CHANGELOG.md): `[Unreleased]` → `## 0.4.3`
- `package-lock.json` regenerated

## Why this is needed

Without this, anyone cloning main today sees `"version": "0.4.2"` in `packages/trpc/package.json` while the npm registry serves 0.4.3 — confusing for contributors. Worse, `release:check:version-sync` and any future release attempt would fail until this is reconciled.

## Test plan

- [x] `npm run release:check:version-sync` → "Version sync OK: all sample workspaces depend on nest-trpc-native@0.4.3"
- [x] Full `npm run release:check` already passed when this commit was produced (`npm run ci` from feature branch tip — same content as this PR — was already green through release-checks before sample-01's unrelated Node-20 glob issue)
- [x] Published `nest-trpc-native@0.4.3` tarball matches this source state