### PR TITLE
fix(sample-01): make unit:test glob work on Node 20

### DIFF
--- a/sample/01-basics-query-mutation/package.json
+++ b/sample/01-basics-query-mutation/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "clean": "rimraf dist src/@generated",
     "generate:types": "ts-node --transpile-only src/generate-types.ts",
-    "unit:test": "node --test --require ts-node/register \"__tests__/**/*.spec.ts\"",
+    "unit:test": "node --require ts-node/register --test $(find __tests__ -name '*.spec.ts')",
     "typecheck": "npm run generate:types && tsc --noEmit -p tsconfig.json",
     "smoke": "npm run generate:types && ts-node --transpile-only scripts/smoke.ts",
     "test": "npm run unit:test && npm run typecheck && npm run smoke",


### PR DESCRIPTION
## Summary

`sample/01-basics-query-mutation`'s `unit:test` script uses `node --test "__tests__/**/*.spec.ts"`. Node only added glob-argument support to `--test` in **Node 21**. On Node 20 — which the root [`package.json`](package.json) declares as supported via `"engines": ">=20"` — Node treats the quoted argument as a literal path and the script fails:

```
Could not find '/workspaces/.../sample/01-basics-query-mutation/__tests__/**/*.spec.ts'
```

This was masked because GitHub CI's `focused-samples` job only runs on Node 22 ([ci.yml:245](.github/workflows/ci.yml#L245)). The Node 20 matrix in CI doesn't exercise sample tests.

## Fix

Replace the glob argument with shell-expanded `find` output:

```diff
- "unit:test": "node --test --require ts-node/register \"__tests__/**/*.spec.ts\"",
+ "unit:test": "node --require ts-node/register --test $(find __tests__ -name '*.spec.ts')",
```

This works on Node 20+ and any POSIX shell. Sample-01 is the only sample with a `unit:test` script; all other samples use only `typecheck` + `smoke`.

## Test plan

- [x] `npm run unit:test` on Node 20.20.2: `# pass 4 # fail 0`
- [ ] CI green on both Node 20 and Node 22 matrix entries

## Context

Surfaced during post-release verification of 0.4.3 — `npm run ci` failed locally on Node 20, all earlier CI steps green. Unrelated to the 0.4.3 fix; pre-existing latent bug in the sample test script.