### PR TITLE
docs: document release tagging convention

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,6 +28,17 @@ Publish the package from the workspace:
 npm publish --workspace nest-trpc-native
 ```
 
+## Tag
+
+After `npm publish` succeeds, tag the release commit on `main`:
+
+```bash
+git tag v<version> <release-commit-sha>
+git push origin v<version>
+```
+
+Use a lightweight tag named `v<version>` (e.g. `v0.4.3`) pointing at the `chore: release v<version>` commit on `main`. This matches the convention used by every release since `v0.1.1`. Tag pushes are not blocked by `main`'s branch-protection rules — push the tag directly, no PR required.
+
 ## Post-publish
 
 1. Confirm the registry version exists:


### PR DESCRIPTION
## Summary

Every release from `v0.1.1` onward has used a lightweight `v<version>` tag pointing at the `chore: release v<version>` commit on main — but this step was **implicit**, not documented in [RELEASING.md](RELEASING.md). v0.4.3 was published without a tag for exactly this reason; the tag had to be added retroactively after the omission was caught.

This PR adds an explicit "Tag" section between **Publish** and **Post-publish** so the next releaser doesn't have to infer the convention from `git tag -l`.

## Change

```diff
+ ## Tag
+
+ After `npm publish` succeeds, tag the release commit on `main`:
+
+ ```bash
+ git tag v<version> <release-commit-sha>
+ git push origin v<version>
+ ```
+
+ Use a lightweight tag named `v<version>` (e.g. `v0.4.3`) pointing at the
+ `chore: release v<version>` commit on `main`. This matches the convention
+ used by every release since `v0.1.1`. Tag pushes are not blocked by
+ `main`'s branch-protection rules — push the tag directly, no PR required.
```

## Note on GUIDELINES_NEST_TRPC.md

I'd also planned to update §9 ("Release Version Synchronization") of `GUIDELINES_NEST_TRPC.md`, but that file is in `.gitignore` and not tracked. If that's intentional (personal notes), no action needed; if not, removing it from `.gitignore` would make the more detailed checklist visible to contributors.