### PR TITLE
chore: ignore .devcontainer/ and .angular/ build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ complexity
 .tmp
 GUIDELINES_NEST_TRPC.md
 todo-*.txt
+.devcontainer/

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ complexity
 GUIDELINES_NEST_TRPC.md
 todo-*.txt
 .devcontainer/
+.angular/


### PR DESCRIPTION
Adds two housekeeping `.gitignore` entries:

- `.devcontainer/` — local dev container config
- `.angular/` — Angular's per-build cache (regenerated on every `ng build`, e.g. the sample/12 showcase)

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)