### PR TITLE
chore: bundle LICENSE, add empty deps block, friendlier docs title

### DIFF
--- a/packages/trpc/LICENSE
+++ b/packages/trpc/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Rodrigo Nogueira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -35,6 +35,7 @@
     "./package.json": "./package.json"
   },
   "files": [
+    "LICENSE",
     "dist/**/*.d.ts",
     "dist/**/*.js",
     "dist/**/*.js.map"
@@ -50,6 +51,7 @@
     "build": "npm run clean && tsc -p tsconfig.build.json",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
+  "dependencies": {},
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
     "@nestjs/core": "^11.0.0",

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const config: Config = {
-  title: '@nest-native/trpc',
+  title: 'NestJS tRPC — @nest-native/trpc',
   tagline: 'Decorator-first tRPC integration for NestJS with full Nest lifecycle support',
   favicon: 'img/favicon.ico',
 
@@ -47,7 +47,7 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: '@nest-native/trpc',
+      title: 'NestJS tRPC',
       items: [
         {
           type: 'docSidebar',


### PR DESCRIPTION
## Summary

Post-rename cosmetic follow-ups (§4.3 of the now-retired `RENAME-HANDOVER`). **No API or behavior changes** — library code untouched.

- **Bundle LICENSE in the npm tarball** — `package.json` declares MIT but the `files` allowlist was `dist/**` only, so the published tarball shipped no LICENSE. Adds `packages/trpc/LICENSE` (copy of the repo-root MIT license) and `"LICENSE"` to `files`. Pack now ships **54 files** (was 53); `scripts/check-package-pack.mjs` already allowlisted `LICENSE`, so `release:check:pack` stays green.
- **Explicit `"dependencies": {}`** in `packages/trpc/package.json` per `GUIDELINES_NEST_TRPC.md` §8 (was absent — functionally identical, but the guideline asks for it explicitly and the dependency-PR checklist verifies it).
- **Friendlier Docusaurus title** — `title` → `NestJS tRPC — @nest-native/trpc`, navbar → `NestJS tRPC`. The npm id and all links stay `@nest-native/trpc`.

## Effect
- LICENSE + empty-deps block land on the **next npm publish**.
- Docs title goes live on the **next Pages deploy**.

## Verification
- `npm run release:check:pack` → `Pack validation OK … 54 expected files`; `LICENSE in tarball: true`
- `npm --prefix website run build` → `[SUCCESS] Generated static files`; rendered `<title>` = `Home | NestJS tRPC — @nest-native/trpc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
