### PR TITLE
ci: add publish-on-tag release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build package
+        run: npm run build --workspace @nest-native/trpc
+      - name: Publish to npm (with provenance)
+        run: npm publish --workspace @nest-native/trpc --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Two-part 0.x maintenance pass (doc + workflow only — no package source, tests, versions, or CHANGELOG touched).

### Task 1 — Honest 0.x framing (no edits needed)
Grepped the human-facing docs (`README.md`, `packages/*/README.md`, `website/docs/**`, `CONTRIBUTING.md`, `RELEASING.md`) for over-committing phrasing (`production-ready`, `v1 surface`, `definition of done for v1`, `v1 ... complete/api/stable`, `status: stable`, `production use`). **Zero genuine hits.** The docs already read as honest `0.x`: the Support Policy frames everything around `0.x` semver, internals "may change during `0.x` stabilization", and the Claims Matrix explicitly forbids over-promising. No swing toward "alpha / do not use" language either. So **0 wording edits**.

### Task 2 — Publish-on-tag release workflow (added)
No existing workflow ran `npm publish` (only `ci.yml` and `deploy-docs.yml`). Added `.github/workflows/release.yml`:

- Triggers only on `v*` tag pushes (matches the existing `v<version>` tag convention in `RELEASING.md`).
- `permissions: id-token: write` for npm provenance.
- `npm ci` → `npm run build --workspace @nest-native/trpc` → `npm publish --workspace @nest-native/trpc --provenance --access public`.
- Requires an `NPM_TOKEN` secret (operator adds it).

Action/runner style matches `ci.yml` (`actions/checkout@v6`, `actions/setup-node@v6`, Node 22). YAML validated with `yaml.safe_load`.

## Notes
- Does not bump the version, tag, or publish. npm READMEs refresh on the next real release (intentional).
- No `GUIDELINES_NEST_*` / constitution changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)