### PR TITLE
docs: scope strictness and audit gate to the core published package

### DIFF
--- a/GUIDELINES_NEST_TRPC.md
+++ b/GUIDELINES_NEST_TRPC.md
@@ -102,6 +102,8 @@ This is not a suggestion — it is the project constitution.
     - Verify `packages/trpc/package.json` still has `"dependencies": {}` after every dependency PR.
     - Run the same validation expected for a human-authored dependency update.
     - Do not auto-accept lockfile churn without understanding which direct dependency caused it.
+- **Strictness scope.** The non-negotiables (100% coverage, cognitive-complexity ≤ 15, zero published runtime deps, isolated major-version review) govern the *core* published package (`packages/trpc`). Non-core code — `sample/*` (including the Angular showcase), the `website/`, and dev tooling — uses lighter rules: their dependency updates (including majors) may merge on green CI without the core's major-isolation ceremony.
+- **Audit scope.** The `security:audit` release gate audits the *published* surface — `npm audit --omit=dev --audit-level=high`. Since the package publishes `"dependencies": {}`, this is exactly what consumers install. Advisories confined to dev/peer/build tooling or the docs `website/` are tracked and patched via Dependabot but do not block releases — they cannot reach consumers. Patch them in their own PRs.
 - Application security checks are required in PR reviews:
   - Auth/authz bypass risk, privilege escalation, and data exposure in handlers, decorators, and context wiring.
   - Input-validation gaps and injection surfaces (command/template/SQL-like patterns, prototype pollution, path traversal).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "release:check:workspace-resolution": "npm ls @nest-native/trpc --workspaces --depth=0",
     "release:check:pack": "npm run build --workspace @nest-native/trpc && node scripts/check-package-pack.mjs",
     "release:check": "npm run release:check:readme-links && npm run release:check:version-sync && npm run release:check:workspace-resolution && npm run release:check:pack",
+    "security:audit:package": "npm audit --omit=dev --audit-level=high",
+    "security:audit": "npm run security:audit:package",
     "docs:test:typecheck": "node scripts/docs-snippets-typecheck.mjs --mode all",
     "docs:test:typecheck:unit": "node scripts/docs-snippets-typecheck.mjs --mode unit",
     "docs:test:typecheck:sample": "node scripts/docs-snippets-typecheck.mjs --mode sample",


### PR DESCRIPTION
Adds two clarifying notes to the constitution's security section so the strictness rules and audit gate are explicitly scoped to the published surface.

## Strictness scope
The non-negotiables (100% coverage, cognitive-complexity ≤ 15, zero published runtime deps, isolated major-version review) govern the *core* published package (`packages/trpc`). Non-core code — `sample/*` (including the Angular showcase), the `website/`, and dev tooling — uses lighter rules: their dependency updates (including majors) may merge on green CI without the core's major-isolation ceremony.

## Audit scope
The `security:audit` release gate audits the *published* surface — `npm audit --omit=dev --audit-level=high`. Since the package publishes `"dependencies": {}`, this is exactly what consumers install. Advisories confined to dev/peer/build tooling or the docs `website/` are tracked and patched via Dependabot but do not block releases — they cannot reach consumers. They are patched in their own PRs.

## Script
Adds `security:audit` / `security:audit:package` (both `npm audit --omit=dev --audit-level=high`) so the gate named in the constitution is runnable and consistent.

> Note: running the gate today exits non-zero because workspace-root `npm audit --omit=dev` audits the union of all workspaces' production deps (sample `@angular/*` and `@nestjs/*` peers, transitive `multer`/`fast-uri`/`qs`/`brace-expansion`). All flagged advisories live in sample/peer/build scope; none are in `packages/trpc`'s published `"dependencies": {}`. This is exactly the non-blocking category the new Audit-scope note describes, to be patched via Dependabot in their own PRs.