### PR TITLE
chore: audit the published tarball surface and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,8 @@ jobs:
       - name: Run focused sample checks
         run: npm run sample:focused
 
-  release-checks:
-    name: Release checks
+  release-and-security:
+    name: Release and security checks
     runs-on: ubuntu-latest
 
     steps:
@@ -265,3 +265,6 @@ jobs:
 
       - name: Run release checks
         run: npm run release:check
+
+      - name: Audit production supply chain
+        run: npm run security:audit

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release:check:workspace-resolution": "npm ls @nest-native/trpc --workspaces --depth=0",
     "release:check:pack": "npm run build --workspace @nest-native/trpc && node scripts/check-package-pack.mjs",
     "release:check": "npm run release:check:readme-links && npm run release:check:version-sync && npm run release:check:workspace-resolution && npm run release:check:pack",
-    "security:audit:package": "npm audit --omit=dev --audit-level=high",
+    "security:audit:package": "node scripts/audit-production-surface.mjs",
     "security:audit": "npm run security:audit:package",
     "docs:test:typecheck": "node scripts/docs-snippets-typecheck.mjs --mode all",
     "docs:test:typecheck:unit": "node scripts/docs-snippets-typecheck.mjs --mode unit",
@@ -45,7 +45,7 @@
     "sample": "npm run showcase && npm run sample:focused && npm run angular-showcase",
     "ci:showcase": "npm run typecheck:client && npm run smoke:express && npm run smoke:fastify",
     "ci:sample": "npm run ci:showcase && npm run sample:focused && npm run angular-showcase",
-    "ci": "npm run test:cov && npm run complexity:check && npm run release:check && npm run ci:docs && npm run ci:sample"
+    "ci": "npm run test:cov && npm run complexity:check && npm run release:check && npm run ci:docs && npm run security:audit && npm run ci:sample"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/audit-production-surface.mjs
+++ b/scripts/audit-production-surface.mjs
@@ -1,0 +1,82 @@
+/**
+ * Audits the *published* supply-chain surface of `@nest-native/trpc`.
+ *
+ * The package publishes `"dependencies": {}`, so the only third-party code a
+ * consumer actually installs is whatever npm pulls in for that empty
+ * production closure (plus any peer deps it chooses to add). Auditing the
+ * monorepo root instead would flag advisories that live exclusively in the
+ * dev/peer/sample tree (e.g. transitive packages reachable only through the
+ * Angular showcase or the `@trpc/client` test harness) — none of which can
+ * reach a consumer. `npm audit --omit=dev` cannot prune those at the root
+ * because npm audits the whole shared-lockfile ideal tree regardless of
+ * `--omit`.
+ *
+ * To audit exactly what consumers install, this script packs the published
+ * tarball, installs it into a throwaway project with `--omit=dev`, and runs
+ * `npm audit --omit=dev --audit-level=high` against that real production closure.
+ * It fails on any high/critical advisory.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const AUDIT_LEVEL = 'high';
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const repoRoot = process.cwd();
+
+const npmCache = fs.mkdtempSync(path.join(os.tmpdir(), 'nest-trpc-native-audit-cache-'));
+const consumerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'nest-trpc-native-audit-consumer-'));
+const npmEnv = { ...process.env, npm_config_cache: npmCache };
+
+function npm(args, options = {}) {
+  return execFileSync(npmExecutable, args, {
+    encoding: 'utf8',
+    env: npmEnv,
+    ...options,
+  });
+}
+
+try {
+  // Build then pack the published package so we audit the real tarball contents.
+  npm(['run', 'build', '--workspace', '@nest-native/trpc'], { cwd: repoRoot, stdio: 'inherit' });
+
+  const packOutput = npm(['pack', '--json', '--workspace', '@nest-native/trpc'], {
+    cwd: repoRoot,
+  });
+  const [packResult] = JSON.parse(packOutput);
+  if (!packResult || typeof packResult.filename !== 'string') {
+    throw new Error('npm pack --json did not return the expected JSON payload.');
+  }
+  // `npm pack --workspace` writes the tarball into the current working
+  // directory (the repo root), not the workspace directory.
+  const tarballPath = path.join(repoRoot, packResult.filename);
+  if (!fs.existsSync(tarballPath)) {
+    throw new Error(`Expected packed tarball not found at ${tarballPath}.`);
+  }
+
+  // Install only the published tarball as a consumer would in production.
+  fs.writeFileSync(
+    path.join(consumerDir, 'package.json'),
+    `${JSON.stringify({ name: 'nest-trpc-native-audit-consumer', version: '0.0.0', private: true }, null, 2)}\n`,
+  );
+  npm(['install', tarballPath, '--omit=dev', '--no-audit', '--no-fund'], {
+    cwd: consumerDir,
+    stdio: 'inherit',
+  });
+
+  // Audit the production closure. npm audit exits non-zero when advisories at or
+  // above --audit-level are present, which propagates out of execFileSync.
+  npm(['audit', '--omit=dev', `--audit-level=${AUDIT_LEVEL}`], {
+    cwd: consumerDir,
+    stdio: 'inherit',
+  });
+
+  fs.rmSync(tarballPath, { force: true });
+  console.log(
+    `\nProduction supply-chain audit OK: ${packResult.filename} has no ${AUDIT_LEVEL}+ advisories in its installed production closure.`,
+  );
+} finally {
+  fs.rmSync(npmCache, { recursive: true, force: true });
+  fs.rmSync(consumerDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## What

Normalizes the production security audit onto the packed-tarball mechanism used by the sibling `nest-native` repos (ai-sdk, drizzle, kafka) **and** wires it into CI, which previously had no audit step at all.

## Why

The root `npm audit --omit=dev` audits npm's whole shared-lockfile ideal tree, so it surfaces advisories that live exclusively in the dev/peer/sample closure (the Angular showcase, the `@trpc/client` test harness) — none of which a consumer of `@nest-native/trpc` can ever install. The published package ships `"dependencies": {}`, so the only third-party code consumers pull in is its real production closure.

## Changes

- **`scripts/audit-production-surface.mjs`** (new): builds, packs the published tarball, installs it into a throwaway project with `--omit=dev`, and runs `npm audit --audit-level=high` against that real production closure. Fails on any high/critical advisory. Adapted from ai-sdk's script for `@nest-native/trpc` (package name, temp-dir prefixes, docstring).
- **`package.json`**: `security:audit:package` now calls the tarball script instead of root `npm audit`. Added `security:audit` to the local `ci` aggregate for parity with the sibling repos.
- **`.github/workflows/ci.yml`**: renamed the `release-checks` job to `release-and-security` and added an **Audit production supply chain** step running `npm run security:audit`, mirroring the sibling repos' "Release and security checks" job. This makes the gate real in CI.

## Validation (local, Node 22)

- `npm ci` clean.
- `npm run security:audit` → `Production supply-chain audit OK: nest-native-trpc-0.5.0.tgz has no high+ advisories in its installed production closure.` (`found 0 vulnerabilities`).
- `npm run release:check` green.
- `packages/trpc` `dependencies` stays `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)