### PR TITLE
feat: tRPC server-config passthrough (transformer, errorFormatter, responseMeta, onError) + subscription docs honesty fix (v0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.0
+
+Server-config passthrough — expose tRPC v11's own server options through `TrpcModuleOptions` (no new runtime dependencies; all four are forwarded untouched):
+
+- add `transformer` (e.g. `superjson`), threaded into `initTRPC.create({ transformer })`, so values such as `Date`/`Map` round-trip between server and client; clients configure the same transformer on their link (`httpBatchLink({ url, transformer })`)
+- when `autoSchemaFile` and `transformer` are combined, the generated `AppRouter` is marked transformer-enabled, so typed clients are required (at compile time) to configure a matching link transformer, and transformed types such as `Date` are inferred as `Date` instead of `string`
+- add `errorFormatter`, threaded into `initTRPC.create({ errorFormatter })`; it composes after the existing `HttpException` → `TRPCError` mapping, enabling the canonical flattened-`ZodError` recipe (`error.data.zodError`)
+- add `responseMeta`, forwarded to the tRPC request handler, for per-response status codes and headers (e.g. `Cache-Control`); headers are applied on both JSON and SSE (subscription) responses, with SSE metadata generated eagerly before streaming starts
+- add `onError`, forwarded to the tRPC request handler, as the standard centralized error-logging/reporting hook
+- add `sample/13-transformer-error-formatting` demonstrating superjson, ZodError flattening, response caching headers, and error reporting
+- docs honesty fix: `@Subscription()` documentation now states that async generators over SSE are the supported streaming shape; tRPC `observable()` return values are not streamed and WebSocket transport is not provided
+
 ## 0.5.0
 
 Project rename to the `@nest-native/*` org standard (no API or behavior changes):

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The documentation site is the canonical source of truth for usage guides and sup
 - Adapter-agnostic behavior across Express and Fastify
 - Zod or `class-validator` validation, without forcing either style on every project
 - Generated `AppRouter` types for fully typed tRPC clients
+- tRPC server-config passthrough: `transformer` (e.g. superjson), `errorFormatter`, `responseMeta`, and `onError`
 
 ## Compatibility
 
@@ -80,6 +81,7 @@ This repository contains:
 | `sample/10-nested-alias-routers` | Nested router aliases | `npm run test --workspace nest-trpc-native-sample-10-nested-alias` |
 | `sample/11-microservice-transport` | tRPC gateway with Nest microservice transport | `npm run test --workspace nest-trpc-native-sample-11-microservice` |
 | `sample/12-angular-fullstack-showcase` | Angular browser client + NestJS backend | `npm run test --workspace nest-trpc-native-sample-12-angular-showcase` |
+| `sample/13-transformer-error-formatting` | superjson transformer, `errorFormatter`, `responseMeta`, `onError` | `npm run test --workspace nest-trpc-native-sample-13-transformer` |
 
 Start with `sample/00-showcase` for end-to-end behavior, then use [sample/README.md](sample/README.md) and [website/docs/samples/index.md](website/docs/samples/index.md) to jump to specific features.
 

--- a/docs/samples/INDEX.md
+++ b/docs/samples/INDEX.md
@@ -18,6 +18,7 @@ This index is the fast path for onboarding and contribution.
 | `sample/10-nested-alias-routers` | Dotted aliases to nested router objects | `npm run test --workspace nest-trpc-native-sample-10-nested-alias` |
 | `sample/11-microservice-transport` | tRPC gateway + Nest microservice transport (TCP) | `npm run test --workspace nest-trpc-native-sample-11-microservice` |
 | `sample/12-angular-fullstack-showcase` | Angular browser client + NestJS backend | `npm run test --workspace nest-trpc-native-sample-12-angular-showcase` |
+| `sample/13-transformer-error-formatting` | superjson transformer + `errorFormatter` + `responseMeta` + `onError` | `npm run test --workspace nest-trpc-native-sample-13-transformer` |
 
 ## Browser Showcase
 
@@ -75,6 +76,7 @@ so the compact backend baseline remains easy to scan.
 | Express/Fastify parity | `sample/00-showcase/src/main.ts`, `sample/00-showcase/src/main-fastify.ts`, `sample/00-showcase/scripts/smoke-*.ts` |
 | Angular client provider | `sample/12-angular-fullstack-showcase/frontend/src/app/trpc/trpc.client.ts` |
 | Angular typed service | `sample/12-angular-fullstack-showcase/frontend/src/app/health/health-api.service.ts` |
+| `transformer` / `errorFormatter` / `responseMeta` / `onError` | `sample/13-transformer-error-formatting/src/app.module.ts`, `sample/13-transformer-error-formatting/scripts/smoke.ts`, `sample/13-transformer-error-formatting/src/client.typecheck.ts` |
 
 ## Contribution Heuristics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "nyc": "^18.0.0",
         "rimraf": "6.1.3",
         "sinon": "22.0.0",
+        "superjson": "^2.2.6",
         "ts-node": "10.9.2",
         "typescript": "6.0.3"
       },
@@ -7385,6 +7386,21 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -7719,9 +7735,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.383",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
-      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "version": "1.5.384",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz",
+      "integrity": "sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==",
       "dev": true,
       "license": "ISC"
     },
@@ -7820,9 +7836,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-3lGxdTXCLfe1MYfTz1y2ksAAUM4NAOP6rPEjxGJVKO7TZ5+tvHCaQWGpC4Y3IXvW3ece0Cz1cIP4FWBxOnGCTQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9332,6 +9348,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -10687,6 +10715,10 @@
     },
     "node_modules/nest-trpc-native-sample-12-angular-showcase": {
       "resolved": "sample/12-angular-fullstack-showcase",
+      "link": true
+    },
+    "node_modules/nest-trpc-native-sample-13-transformer": {
+      "resolved": "sample/13-transformer-error-formatting",
       "link": true
     },
     "node_modules/nest-trpc-native-showcase": {
@@ -13167,6 +13199,18 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -14885,7 +14929,7 @@
     },
     "packages/trpc": {
       "name": "@nest-native/trpc",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "devDependencies": {
         "@nestjs/common": "^11.1.27",
@@ -14917,7 +14961,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15810,7 +15854,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15831,7 +15875,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15852,7 +15896,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15873,7 +15917,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15895,7 +15939,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15918,7 +15962,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15940,7 +15984,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15963,7 +16007,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -15984,7 +16028,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "11.1.27",
@@ -16006,7 +16050,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -16027,7 +16071,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/microservices": "11.1.27",
@@ -16053,7 +16097,7 @@
         "@angular/compiler": "22.0.4",
         "@angular/core": "22.0.4",
         "@angular/platform-browser": "22.0.4",
-        "@nest-native/trpc": "0.5.0",
+        "@nest-native/trpc": "0.6.0",
         "@nestjs/common": "11.1.27",
         "@nestjs/core": "11.1.27",
         "@nestjs/platform-express": "11.1.27",
@@ -16942,6 +16986,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "sample/13-transformer-error-formatting": {
+      "name": "nest-trpc-native-sample-13-transformer",
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@nest-native/trpc": "0.6.0",
+        "@nestjs/common": "11.1.27",
+        "@nestjs/core": "11.1.27",
+        "@nestjs/platform-express": "11.1.27",
+        "@trpc/client": "^11.18.0",
+        "@trpc/server": "^11.16.0",
+        "reflect-metadata": "0.2.2",
+        "rimraf": "6.1.3",
+        "rxjs": "7.8.2",
+        "superjson": "^2.2.6",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "25.9.3",
+        "ts-node": "10.9.2",
+        "typescript": "6.0.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "smoke:fastify": "npm run smoke:fastify --workspace nest-trpc-native-showcase",
     "showcase": "npm run test --workspace nest-trpc-native-showcase",
     "presample:focused": "npm run build --workspace @nest-native/trpc",
-    "sample:focused": "npm run test --workspace nest-trpc-native-sample-01-basics && npm run test --workspace nest-trpc-native-sample-02-enhancers && npm run test --workspace nest-trpc-native-sample-03-context && npm run test --workspace nest-trpc-native-sample-04-zod && npm run test --workspace nest-trpc-native-sample-05-class-validator && npm run test --workspace nest-trpc-native-sample-06-subscriptions && npm run test --workspace nest-trpc-native-sample-07-adapters && npm run test --workspace nest-trpc-native-sample-08-autoschema && npm run test --workspace nest-trpc-native-sample-09-config-middleware && npm run test --workspace nest-trpc-native-sample-10-nested-alias && npm run test --workspace nest-trpc-native-sample-11-microservice",
+    "sample:focused": "npm run test --workspace nest-trpc-native-sample-01-basics && npm run test --workspace nest-trpc-native-sample-02-enhancers && npm run test --workspace nest-trpc-native-sample-03-context && npm run test --workspace nest-trpc-native-sample-04-zod && npm run test --workspace nest-trpc-native-sample-05-class-validator && npm run test --workspace nest-trpc-native-sample-06-subscriptions && npm run test --workspace nest-trpc-native-sample-07-adapters && npm run test --workspace nest-trpc-native-sample-08-autoschema && npm run test --workspace nest-trpc-native-sample-09-config-middleware && npm run test --workspace nest-trpc-native-sample-10-nested-alias && npm run test --workspace nest-trpc-native-sample-11-microservice && npm run test --workspace nest-trpc-native-sample-13-transformer",
     "angular-showcase": "npm run test --workspace nest-trpc-native-sample-12-angular-showcase",
     "sample": "npm run showcase && npm run sample:focused && npm run angular-showcase",
     "ci:showcase": "npm run typecheck:client && npm run smoke:express && npm run smoke:fastify",
@@ -65,6 +65,7 @@
     "nyc": "^18.0.0",
     "rimraf": "6.1.3",
     "sinon": "22.0.0",
+    "superjson": "^2.2.6",
     "ts-node": "10.9.2",
     "typescript": "6.0.3"
   },

--- a/packages/trpc/README.md
+++ b/packages/trpc/README.md
@@ -32,6 +32,7 @@ It makes tRPC feel native in Nest applications:
 - Adapter-agnostic behavior across Express and Fastify
 - Zod or `class-validator` validation, without forcing either style on every project
 - Generated `AppRouter` types for fully typed tRPC clients
+- tRPC server-config passthrough: `transformer` (e.g. superjson), `errorFormatter`, `responseMeta`, and `onError`
 
 ## Documentation
 

--- a/packages/trpc/generators/schema-generator.ts
+++ b/packages/trpc/generators/schema-generator.ts
@@ -20,6 +20,15 @@ interface RenderableProcedure extends ProcedureInfo {
   outputSchemaVarName?: string;
 }
 
+export interface SchemaGeneratorOptions {
+  /**
+   * When the server is configured with a `transformer`, the generated
+   * router type must reflect it so typed clients are required to
+   * configure the matching link transformer.
+   */
+  hasTransformer?: boolean;
+}
+
 /**
  * Generates a TypeScript file containing the typed `AppRouter`
  * for tRPC client consumption.
@@ -30,8 +39,12 @@ interface RenderableProcedure extends ProcedureInfo {
  *
  * @internal
  */
-export function generateSchema(routers: RouterInfo[], filePath: string): void {
-  const content = generateSchemaContent(routers);
+export function generateSchema(
+  routers: RouterInfo[],
+  filePath: string,
+  options: SchemaGeneratorOptions = {},
+): void {
+  const content = generateSchemaContent(routers, options);
   mkdirSync(dirname(filePath), { recursive: true });
   writeFileSync(filePath, content, 'utf-8');
 }
@@ -42,7 +55,10 @@ export function generateSchema(routers: RouterInfo[], filePath: string): void {
  *
  * @internal
  */
-export function generateSchemaContent(routers: RouterInfo[]): string {
+export function generateSchemaContent(
+  routers: RouterInfo[],
+  options: SchemaGeneratorOptions = {},
+): string {
   const lines: string[] = [
     '// ------------------------------------------------------',
     '// THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)',
@@ -60,7 +76,20 @@ export function generateSchemaContent(routers: RouterInfo[]): string {
   }
 
   lines.push('');
-  lines.push('const t = initTRPC.create();');
+  if (options.hasTransformer) {
+    lines.push(
+      '// Type-level marker mirroring the transformer configured on the server.',
+      '// Clients must configure the matching transformer on their link,',
+      '// e.g. httpBatchLink({ url, transformer: superjson }).',
+      'const transformer = {',
+      '  serialize: (value: unknown) => value,',
+      '  deserialize: (value: unknown) => value,',
+      '};',
+      'const t = initTRPC.create({ transformer });',
+    );
+  } else {
+    lines.push('const t = initTRPC.create();');
+  }
   lines.push('');
 
   // Group procedures: aliased → sub-routers, un-aliased → root

--- a/packages/trpc/interfaces.ts
+++ b/packages/trpc/interfaces.ts
@@ -1,4 +1,12 @@
 import { ModuleMetadata } from '@nestjs/common';
+import type {
+  AnyRouter,
+  CombinedDataTransformer,
+  DataTransformer,
+  TRPCErrorFormatter,
+  TRPCErrorShape,
+} from '@trpc/server';
+import type { HTTPErrorHandler, ResponseMetaFn } from '@trpc/server/http';
 
 export interface TrpcModuleOptions<TContext = any> {
   /**
@@ -43,6 +51,102 @@ export interface TrpcModuleOptions<TContext = any> {
    * ```
    */
   autoSchemaFile?: string;
+
+  /**
+   * A tRPC data transformer (e.g. `superjson`) used to serialize and
+   * deserialize payloads, enabling types such as `Date` and `Map` to
+   * round-trip between server and client.
+   *
+   * Passed straight through to `initTRPC.create({ transformer })`.
+   * Clients must configure the **same** transformer on their terminating
+   * link, e.g. `httpBatchLink({ url, transformer: superjson })`.
+   *
+   * When set together with `autoSchemaFile`, the generated `AppRouter`
+   * type marks the router as transformer-enabled so typed clients are
+   * required to configure a link transformer.
+   *
+   * @see https://trpc.io/docs/server/data-transformers
+   *
+   * @example
+   * ```ts
+   * import superjson from 'superjson';
+   *
+   * TrpcModule.forRoot({ transformer: superjson })
+   * ```
+   */
+  transformer?: DataTransformer | CombinedDataTransformer;
+
+  /**
+   * Custom tRPC error formatter used to shape the error payload sent to
+   * clients. Passed straight through to `initTRPC.create({ errorFormatter })`.
+   *
+   * The formatter runs *after* this library maps thrown `HttpException`s
+   * to `TRPCError`s, so `error.code` already reflects the mapped tRPC code.
+   *
+   * @see https://trpc.io/docs/server/error-formatting
+   *
+   * @example
+   * ```ts
+   * import { z, ZodError } from 'zod';
+   *
+   * TrpcModule.forRoot({
+   *   errorFormatter: ({ shape, error }) => ({
+   *     ...shape,
+   *     data: {
+   *       ...shape.data,
+   *       zodError:
+   *         error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+   *           ? z.flattenError(error.cause)
+   *           : null,
+   *     },
+   *   }),
+   * })
+   * ```
+   */
+  errorFormatter?: TRPCErrorFormatter<TContext, TRPCErrorShape>;
+
+  /**
+   * Hook to set the HTTP status and extra headers of tRPC responses,
+   * e.g. `Cache-Control` for public queries. Passed straight through to
+   * the tRPC request handler (`responseMeta`).
+   *
+   * For streamed responses (subscriptions over SSE), the hook runs eagerly
+   * (`eagerGeneration: true`) before the first chunk is written, so returned
+   * headers are applied to the streaming response as well; a returned
+   * `status` cannot rewrite the status of an already-streaming response.
+   *
+   * @see https://trpc.io/docs/server/caching
+   *
+   * @example
+   * ```ts
+   * TrpcModule.forRoot({
+   *   responseMeta: ({ type, errors }) =>
+   *     type === 'query' && errors.length === 0
+   *       ? { headers: { 'cache-control': 'public, max-age=60' } }
+   *       : {},
+   * })
+   * ```
+   */
+  responseMeta?: ResponseMetaFn<AnyRouter>;
+
+  /**
+   * Hook invoked whenever a procedure call fails, before the error
+   * response is sent. The standard place for centralized error logging
+   * and reporting. Passed straight through to the tRPC request handler
+   * (`onError`). `opts.req` is the Fetch API `Request` handed to tRPC.
+   *
+   * @see https://trpc.io/docs/server/error-handling
+   *
+   * @example
+   * ```ts
+   * TrpcModule.forRoot({
+   *   onError: ({ error, path }) => {
+   *     logger.error(`tRPC error on "${path}": ${error.message}`);
+   *   },
+   * })
+   * ```
+   */
+  onError?: HTTPErrorHandler<AnyRouter, Request>;
 }
 
 export interface TrpcModuleAsyncOptions<TContext = any> extends Pick<

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nest-native/trpc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Decorator-first tRPC integration bridge for NestJS",
   "keywords": [
     "nestjs",

--- a/packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts
+++ b/packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts
@@ -17,7 +17,8 @@ import {
 import { expect } from 'chai';
 import { EventSource } from 'eventsource';
 import { IsString, MinLength } from 'class-validator';
-import { z } from 'zod';
+import superjson from 'superjson';
+import { z, ZodError } from 'zod';
 import { TrpcContext } from '../../decorators/ctx.decorator';
 import { Input } from '../../decorators/input.decorator';
 import {
@@ -152,6 +153,80 @@ async function expectClientError(
   expect(String(error?.message)).to.match(expectedMessage);
 }
 
+const FIXED_DATE = new Date('2026-01-02T03:04:05.000Z');
+
+@Router('calendar')
+class TransformerE2ERouter {
+  @Query()
+  when() {
+    return { at: FIXED_DATE };
+  }
+
+  @Mutation({ input: z.object({ dueAt: z.date() }) })
+  echoDate(@Input('dueAt') dueAt: Date) {
+    return { received: dueAt, isDate: dueAt instanceof Date };
+  }
+
+  @Subscription()
+  async *pulse() {
+    yield { at: FIXED_DATE };
+  }
+}
+
+async function createTransformerApp(
+  kind: AdapterKind,
+): Promise<INestApplication> {
+  const moduleRef: TestingModule = await Test.createTestingModule({
+    imports: [
+      TrpcModule.forRoot({
+        path: TRPC_PATH,
+        transformer: superjson,
+        errorFormatter: ({ shape, error }) => ({
+          ...shape,
+          data: {
+            ...shape.data,
+            zodError:
+              error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+                ? z.flattenError(error.cause)
+                : null,
+          },
+        }),
+      }),
+    ],
+    providers: [TransformerE2ERouter],
+  }).compile();
+
+  const app =
+    kind === 'fastify'
+      ? moduleRef.createNestApplication<NestFastifyApplication>(
+          new FastifyAdapter(),
+        )
+      : moduleRef.createNestApplication();
+
+  await app.init();
+  await app.listen(0, '127.0.0.1');
+  return app;
+}
+
+function createTransformerClient(baseUrl: string) {
+  return createTRPCProxyClient<any>({
+    links: [
+      splitLink({
+        condition: operation => operation.type === 'subscription',
+        true: httpSubscriptionLink({
+          url: `${baseUrl}${TRPC_PATH}`,
+          transformer: superjson,
+          EventSource,
+        }),
+        false: httpBatchLink({
+          url: `${baseUrl}${TRPC_PATH}`,
+          transformer: superjson,
+        }),
+      }),
+    ],
+  });
+}
+
 describe('real @trpc/client adapter E2E', () => {
   for (const adapterKind of ['express', 'fastify'] as const) {
     describe(adapterKind, () => {
@@ -220,6 +295,76 @@ describe('real @trpc/client adapter E2E', () => {
         });
 
         expect(ticks).to.deep.equal([1, 2, 3]);
+      });
+    });
+  }
+});
+
+describe('real @trpc/client with superjson transformer E2E', () => {
+  for (const adapterKind of ['express', 'fastify'] as const) {
+    describe(adapterKind, () => {
+      let app: INestApplication;
+      let client: any;
+
+      before(async () => {
+        app = await createTransformerApp(adapterKind);
+        client = createTransformerClient(await app.getUrl());
+      });
+
+      after(async () => {
+        await app?.close();
+      });
+
+      it('round-trips Date instances through queries', async () => {
+        const result = await client.calendar.when.query();
+        expect(result.at).to.be.instanceOf(Date);
+        expect(result.at.toISOString()).to.equal(FIXED_DATE.toISOString());
+      });
+
+      it('round-trips Date instances through mutation inputs and outputs', async () => {
+        const result = await client.calendar.echoDate.mutate({
+          dueAt: FIXED_DATE,
+        });
+        expect(result.isDate).to.equal(true);
+        expect(result.received).to.be.instanceOf(Date);
+        expect(result.received.toISOString()).to.equal(
+          FIXED_DATE.toISOString(),
+        );
+      });
+
+      it('round-trips Date instances through SSE subscriptions', async function () {
+        this.timeout(5000);
+
+        const events: Array<{ at: Date }> = [];
+        await new Promise<void>((resolve, reject) => {
+          client.calendar.pulse.subscribe(undefined, {
+            onData(event: { at: Date }) {
+              events.push(event);
+            },
+            onError(error: unknown) {
+              reject(error);
+            },
+            onComplete() {
+              resolve();
+            },
+          });
+        });
+
+        expect(events).to.have.length(1);
+        expect(events[0].at).to.be.instanceOf(Date);
+        expect(events[0].at.toISOString()).to.equal(FIXED_DATE.toISOString());
+      });
+
+      it('exposes the flattened ZodError shape to the real client', async () => {
+        let error: any;
+        try {
+          await client.calendar.echoDate.mutate({ dueAt: 'not-a-date' });
+        } catch (err) {
+          error = err;
+        }
+
+        expect(error).to.be.instanceOf(Error);
+        expect(error?.data?.zodError?.fieldErrors?.dueAt).to.be.an('array');
       });
     });
   }

--- a/packages/trpc/test/adapter/trpc-http-adapter.spec.ts
+++ b/packages/trpc/test/adapter/trpc-http-adapter.spec.ts
@@ -16,8 +16,9 @@ import {
   NestFastifyApplication,
 } from '@nestjs/platform-fastify';
 import { Test, TestingModule } from '@nestjs/testing';
+import superjson from 'superjson';
 import { map, Observable } from 'rxjs';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 import { Input } from '../../decorators/input.decorator';
 import { Router } from '../../decorators/router.decorator';
 import {
@@ -423,6 +424,244 @@ describe('TrpcHttpAdapter', () => {
       expect(body.result.data).to.deep.equal([{ id: '1', name: 'Item 1' }]);
 
       await fastApp.close();
+    });
+  });
+});
+
+@Router('cfg')
+class ServerConfigRouter {
+  @Query()
+  now() {
+    return { at: new Date('2026-01-02T03:04:05.000Z') };
+  }
+
+  @Mutation({ input: z.object({ title: z.string().min(3) }) })
+  create(input: { title: string }) {
+    return input;
+  }
+
+  @Mutation()
+  explode() {
+    throw new BadRequestException('invalid payload');
+  }
+
+  @Subscription({ output: z.object({ tick: z.number() }) })
+  async *ticks() {
+    yield { tick: 1 };
+  }
+}
+
+describe('TrpcHttpAdapter (server config passthrough)', () => {
+  let onErrorCalls: Array<{ path?: string; code: string }>;
+
+  function createPassthroughModule(): Promise<TestingModule> {
+    return Test.createTestingModule({
+      imports: [
+        TrpcModule.forRoot({
+          path: '/trpc',
+          transformer: superjson,
+          errorFormatter: ({ shape, error }) => ({
+            ...shape,
+            data: {
+              ...shape.data,
+              custom: `formatted:${error.code}`,
+              zodError:
+                error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+                  ? z.flattenError(error.cause)
+                  : null,
+            },
+          }),
+          responseMeta: ({ type, errors, eagerGeneration }) => ({
+            status:
+              type === 'query' && errors.length === 0 && !eagerGeneration
+                ? 207
+                : undefined,
+            headers: {
+              'x-response-meta': eagerGeneration ? 'eager' : 'standard',
+              'cache-control': 'public, max-age=60',
+            },
+          }),
+          onError: ({ path, error }) => {
+            onErrorCalls.push({ path, code: error.code });
+          },
+        }),
+      ],
+      providers: [ServerConfigRouter],
+    }).compile();
+  }
+
+  describe('Express', () => {
+    let app: any;
+    let port: number;
+
+    beforeEach(async () => {
+      onErrorCalls = [];
+      const module = await createPassthroughModule();
+      app = module.createNestApplication();
+      await app.init();
+      await app.listen(0);
+      port = app.getHttpServer().address().port;
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('should serialize responses with the configured transformer', async () => {
+      const response = await fetch(`http://localhost:${port}/trpc/cfg.now`, {
+        method: 'GET',
+      });
+
+      const body = await response.json();
+      expect(body.result.data.json.at).to.equal('2026-01-02T03:04:05.000Z');
+      expect(body.result.data.meta.values).to.deep.equal({ at: ['Date'] });
+    });
+
+    it('should apply responseMeta status and headers on the JSON path', async () => {
+      const response = await fetch(`http://localhost:${port}/trpc/cfg.now`, {
+        method: 'GET',
+      });
+
+      expect(response.status).to.equal(207);
+      expect(response.headers.get('x-response-meta')).to.equal('standard');
+      expect(response.headers.get('cache-control')).to.equal(
+        'public, max-age=60',
+      );
+    });
+
+    it('should apply responseMeta headers before streaming SSE responses', async function () {
+      this.timeout(5000);
+
+      const response = await fetch(`http://localhost:${port}/trpc/cfg.ticks`, {
+        method: 'GET',
+        headers: { accept: 'text/event-stream' },
+      });
+
+      expect(response.status).to.equal(200);
+      expect(response.headers.get('content-type')).to.include(
+        'text/event-stream',
+      );
+      expect(response.headers.get('x-response-meta')).to.equal('eager');
+      // tRPC appends responseMeta headers to its own SSE cache-control
+      // ("no-cache, no-transform"), so assert containment on this path.
+      expect(response.headers.get('cache-control')).to.include(
+        'public, max-age=60',
+      );
+
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let ssePayload = '';
+      for (let i = 0; i < 5; i += 1) {
+        const chunk = await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            setTimeout(
+              () => reject(new Error('Timed out waiting for SSE chunk')),
+              1500,
+            );
+          }),
+        ]);
+
+        if (chunk.done) {
+          break;
+        }
+        if (chunk.value) {
+          ssePayload += decoder.decode(chunk.value, { stream: true });
+        }
+        if (ssePayload.includes('"tick":1')) {
+          break;
+        }
+      }
+
+      expect(ssePayload).to.include('"tick":1');
+      await reader.cancel();
+    });
+
+    it('should invoke onError when a procedure fails', async () => {
+      const response = await fetch(
+        `http://localhost:${port}/trpc/cfg.explode`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      expect(onErrorCalls).to.deep.equal([
+        { path: 'cfg.explode', code: 'BAD_REQUEST' },
+      ]);
+    });
+
+    it('should run errorFormatter after HttpException -> TRPCError mapping', async () => {
+      const response = await fetch(
+        `http://localhost:${port}/trpc/cfg.explode`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        },
+      );
+
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      const errorShape = body.error.json;
+      expect(errorShape.data.code).to.equal('BAD_REQUEST');
+      expect(errorShape.data.custom).to.equal('formatted:BAD_REQUEST');
+      expect(String(errorShape.message)).to.include('invalid payload');
+    });
+
+    it('should expose flattened ZodErrors through the errorFormatter recipe', async () => {
+      const response = await fetch(`http://localhost:${port}/trpc/cfg.create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(superjson.serialize({ title: 'x' })),
+      });
+
+      expect(response.status).to.equal(400);
+      const body = await response.json();
+      const errorShape = body.error.json;
+      expect(errorShape.data.custom).to.equal('formatted:BAD_REQUEST');
+      expect(errorShape.data.zodError.fieldErrors.title).to.be.an('array');
+      expect(errorShape.data.zodError.fieldErrors.title.join(' ')).to.match(
+        /3/,
+      );
+    });
+  });
+
+  describe('Fastify', () => {
+    let fastifyApp: NestFastifyApplication;
+    let fastifyPort: number;
+
+    beforeEach(async () => {
+      onErrorCalls = [];
+      const module = await createPassthroughModule();
+      fastifyApp = module.createNestApplication<NestFastifyApplication>(
+        new FastifyAdapter(),
+      );
+      await fastifyApp.init();
+      await fastifyApp.listen(0, '127.0.0.1');
+      const address = fastifyApp.getHttpServer().address();
+      if (!address || typeof address === 'string') {
+        throw new Error('Fastify server did not bind to a TCP port');
+      }
+      fastifyPort = address.port;
+    });
+
+    afterEach(async () => {
+      await fastifyApp.close();
+    });
+
+    it('should apply transformer and responseMeta on the JSON path', async () => {
+      const response = await fetch(
+        `http://localhost:${fastifyPort}/trpc/cfg.now`,
+        { method: 'GET' },
+      );
+
+      expect(response.status).to.equal(207);
+      expect(response.headers.get('x-response-meta')).to.equal('standard');
+      const body = await response.json();
+      expect(body.result.data.meta.values).to.deep.equal({ at: ['Date'] });
     });
   });
 });

--- a/packages/trpc/test/generators/schema-generator.spec.ts
+++ b/packages/trpc/test/generators/schema-generator.spec.ts
@@ -240,6 +240,29 @@ describe('generateSchemaContent', () => {
     );
   });
 
+  it('should emit a bare initTRPC.create() when hasTransformer is false', () => {
+    const content = generateSchemaContent(
+      [{ procedures: [{ name: 'ping', type: ProcedureType.QUERY }] }],
+      { hasTransformer: false },
+    );
+
+    expect(content).to.include('const t = initTRPC.create();');
+    expect(content).to.not.include('const transformer = {');
+  });
+
+  it('should emit a transformer marker when hasTransformer is true', () => {
+    const content = generateSchemaContent(
+      [{ procedures: [{ name: 'ping', type: ProcedureType.QUERY }] }],
+      { hasTransformer: true },
+    );
+
+    expect(content).to.include('const transformer = {');
+    expect(content).to.include('  serialize: (value: unknown) => value,');
+    expect(content).to.include('  deserialize: (value: unknown) => value,');
+    expect(content).to.include('const t = initTRPC.create({ transformer });');
+    expect(content).to.not.include('const t = initTRPC.create();');
+  });
+
   it('should keep generated schema formatting stable', () => {
     const content = generateSchemaContent([
       {
@@ -320,6 +343,21 @@ describe('generateSchema (file output)', () => {
     const content = readFileSync(tmpFile, 'utf-8');
     expect(content).to.include('export type AppRouter = typeof appRouter');
     expect(content).to.include('health: t.procedure.query');
+    expect(content).to.include('const t = initTRPC.create();');
+  });
+
+  it('should write the transformer marker when hasTransformer is set', () => {
+    const routers: RouterInfo[] = [
+      {
+        procedures: [{ name: 'health', type: ProcedureType.QUERY }],
+      },
+    ];
+
+    generateSchema(routers, tmpFile, { hasTransformer: true });
+
+    expect(existsSync(tmpFile)).to.be.true;
+    const content = readFileSync(tmpFile, 'utf-8');
+    expect(content).to.include('const t = initTRPC.create({ transformer });');
   });
 });
 
@@ -433,6 +471,113 @@ describe('generateSchemaContent (type-level AppRouter contract)', () => {
           `Typecheck failed.\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`,
         );
       }
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should require a link transformer on typed clients when generated with hasTransformer', function () {
+    this.timeout(30000);
+    const tempDir = mkdtempSync(
+      join(process.cwd(), 'packages/trpc/.tmp-trpc-transformer-types-'),
+    );
+    const generatedFile = join(tempDir, 'generated.ts');
+    const clientWithTransformerFile = join(tempDir, 'client-with.ts');
+    const clientMissingTransformerFile = join(tempDir, 'client-missing.ts');
+
+    const runTsc = (entryFile: string): { ok: boolean; output: string } => {
+      const tscEntry = require.resolve('typescript/bin/tsc');
+      try {
+        execFileSync(
+          process.execPath,
+          [
+            tscEntry,
+            '--noEmit',
+            '--strict',
+            '--target',
+            'ES2021',
+            '--module',
+            'commonjs',
+            '--moduleResolution',
+            'node',
+            '--ignoreDeprecations',
+            '6.0',
+            '--skipLibCheck',
+            entryFile,
+          ],
+          { cwd: process.cwd(), stdio: 'pipe' },
+        );
+        return { ok: true, output: '' };
+      } catch (error) {
+        const execError = error as Error & { stdout?: Buffer; stderr?: Buffer };
+        return {
+          ok: false,
+          output:
+            (execError.stdout?.toString('utf-8') ?? '') +
+            (execError.stderr?.toString('utf-8') ?? ''),
+        };
+      }
+    };
+
+    try {
+      generateSchema(
+        [
+          {
+            procedures: [
+              {
+                name: 'when',
+                type: ProcedureType.QUERY,
+              },
+            ],
+          },
+        ],
+        generatedFile,
+        { hasTransformer: true },
+      );
+
+      writeFileSync(
+        clientWithTransformerFile,
+        [
+          "import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';",
+          "import type { AppRouter } from './generated';",
+          '',
+          'const transformer = {',
+          '  serialize: (value: unknown) => value,',
+          '  deserialize: (value: unknown) => value,',
+          '};',
+          '',
+          'export const client = createTRPCProxyClient<AppRouter>({',
+          "  links: [httpBatchLink({ url: 'http://localhost:3000/trpc', transformer })],",
+          '});',
+          '',
+        ].join('\n'),
+      );
+
+      writeFileSync(
+        clientMissingTransformerFile,
+        [
+          "import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';",
+          "import type { AppRouter } from './generated';",
+          '',
+          'export const client = createTRPCProxyClient<AppRouter>({',
+          "  links: [httpBatchLink({ url: 'http://localhost:3000/trpc' })],",
+          '});',
+          '',
+        ].join('\n'),
+      );
+
+      const withTransformer = runTsc(clientWithTransformerFile);
+      expect(
+        withTransformer.ok,
+        `Expected typecheck to pass:\n${withTransformer.output}`,
+      ).to.equal(true);
+
+      const missingTransformer = runTsc(clientMissingTransformerFile);
+      expect(
+        missingTransformer.ok,
+        'Expected typecheck to fail when the link transformer is missing',
+      ).to.equal(false);
+      expect(missingTransformer.output).to.include('transformer');
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }

--- a/packages/trpc/test/router/trpc-router-lifecycle.spec.ts
+++ b/packages/trpc/test/router/trpc-router-lifecycle.spec.ts
@@ -310,6 +310,41 @@ describe('TrpcRouter Lifecycle', () => {
     expect(generated).to.include('export type AppRouter = typeof appRouter;');
     expect(generated).to.include('lifecycle: t.router({');
     expect(generated).to.include('events: t.router({');
+    expect(generated).to.include('const t = initTRPC.create();');
+  });
+
+  it('should mark generated AppRouter types when a transformer is configured', async () => {
+    const transformerTmpDir = mkdtempSync(join(tmpdir(), 'trpc-schema-'));
+    const transformerSchemaPath = join(
+      transformerTmpDir,
+      'generated',
+      'server.ts',
+    );
+
+    const transformerModuleRef = await Test.createTestingModule({
+      imports: [
+        TrpcModule.forRoot({
+          path: '/trpc',
+          autoSchemaFile: transformerSchemaPath,
+          transformer: {
+            serialize: (value: unknown) => value,
+            deserialize: (value: unknown) => value,
+          },
+        }),
+      ],
+      providers: [GlobalLifecycleRouter],
+    }).compile();
+
+    try {
+      await transformerModuleRef.init();
+      const generated = readFileSync(transformerSchemaPath, 'utf-8');
+      expect(generated).to.include(
+        'const t = initTRPC.create({ transformer });',
+      );
+    } finally {
+      await transformerModuleRef.close();
+      rmSync(transformerTmpDir, { recursive: true, force: true });
+    }
   });
 
   it('should support class-validator DTO validation through ValidationPipe', async () => {

--- a/packages/trpc/trpc-http-adapter.ts
+++ b/packages/trpc/trpc-http-adapter.ts
@@ -48,6 +48,8 @@ export class TrpcHttpAdapter implements OnModuleInit {
               createContext: createContext
                 ? () => createContext({ req, res })
                 : undefined,
+              responseMeta: this.options.responseMeta,
+              onError: this.options.onError,
             };
             return fetchRequestHandler(handlerOpts);
           })

--- a/packages/trpc/trpc-router.ts
+++ b/packages/trpc/trpc-router.ts
@@ -84,7 +84,9 @@ export class TrpcRouter<
     this.appRouter = this.buildRouter() as TRouter;
 
     if (this.options.autoSchemaFile) {
-      generateSchema(this.collectedRouterInfos, this.options.autoSchemaFile);
+      generateSchema(this.collectedRouterInfos, this.options.autoSchemaFile, {
+        hasTransformer: Boolean(this.options.transformer),
+      });
       this.logger.log(
         `Generated AppRouter types at "${this.options.autoSchemaFile}"`,
       );
@@ -106,7 +108,10 @@ export class TrpcRouter<
 
   private buildRouter(): AnyRouter {
     const state: RouterBuildState = {
-      trpc: initTRPC.context<any>().create(),
+      trpc: initTRPC.context<any>().create({
+        transformer: this.options.transformer,
+        errorFormatter: this.options.errorFormatter,
+      }),
       routerMap: {},
       registeredAliases: new Set<string>(),
       namespaceAliases: new Set<string>(),

--- a/sample/00-showcase/package.json
+++ b/sample/00-showcase/package.json
@@ -31,7 +31,7 @@
     "class-validator": "0.15.1",
     "eventsource": "4.1.0",
     "fastify": "5.8.5",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/01-basics-query-mutation/package.json
+++ b/sample/01-basics-query-mutation/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/02-enhancers-guards-pipes-filters/package.json
+++ b/sample/02-enhancers-guards-pipes-filters/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/03-context-request-scope/package.json
+++ b/sample/03-context-request-scope/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/04-validation-zod/package.json
+++ b/sample/04-validation-zod/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2",

--- a/sample/06-subscriptions/README.md
+++ b/sample/06-subscriptions/README.md
@@ -5,9 +5,8 @@ This sample is a runnable extraction focused on server-side subscriptions and cl
 It demonstrates:
 
 - `@Subscription(...)` procedures
-- async generator events
-- `observable()` events from `@trpc/server/observable`
-- typed client subscription usage (`httpSubscriptionLink`)
+- async generator events (the supported streaming shape)
+- typed client subscription usage over SSE (`httpSubscriptionLink`)
 
 ## Run
 

--- a/sample/06-subscriptions/package.json
+++ b/sample/06-subscriptions/package.json
@@ -21,7 +21,7 @@
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
     "eventsource": "4.1.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/07-express-fastify/package.json
+++ b/sample/07-express-fastify/package.json
@@ -22,7 +22,7 @@
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
     "fastify": "5.8.5",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/08-autoschema-client-typecheck/package.json
+++ b/sample/08-autoschema-client-typecheck/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/09-forrootasync-config-middleware/package.json
+++ b/sample/09-forrootasync-config-middleware/package.json
@@ -19,7 +19,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/10-nested-alias-routers/package.json
+++ b/sample/10-nested-alias-routers/package.json
@@ -18,7 +18,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/11-microservice-transport/package.json
+++ b/sample/11-microservice-transport/package.json
@@ -20,7 +20,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
     "rxjs": "7.8.2"

--- a/sample/12-angular-fullstack-showcase/package.json
+++ b/sample/12-angular-fullstack-showcase/package.json
@@ -32,7 +32,7 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "@nest-native/trpc": "0.5.0",
+    "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",

--- a/sample/13-transformer-error-formatting/.gitignore
+++ b/sample/13-transformer-error-formatting/.gitignore
@@ -1,0 +1,3 @@
+dist
+src/@generated
+.local

--- a/sample/13-transformer-error-formatting/README.md
+++ b/sample/13-transformer-error-formatting/README.md
@@ -1,0 +1,23 @@
+# Sample 13: Transformer + Error Formatting + Response Meta
+
+This sample is a runnable extraction for the tRPC server-config passthrough options on `TrpcModule.forRoot()`.
+
+It demonstrates:
+
+- `transformer: superjson` — `Date` round-trips between server and client; the generated `AppRouter` marks the router as transformer-enabled, so typed clients are **required** to pass `transformer` to their link
+- `errorFormatter` — the canonical flattened-`ZodError` recipe (`error.data.zodError.fieldErrors`)
+- `responseMeta` — a `Cache-Control` header on successful queries
+- `onError` — a centralized server-side error reporting hook
+
+## Run
+
+```bash
+npm run test --workspace nest-trpc-native-sample-13-transformer
+```
+
+## Key Files
+
+- `src/app.module.ts`
+- `src/tasks/tasks.router.ts`
+- `src/client.typecheck.ts`
+- `scripts/smoke.ts`

--- a/sample/13-transformer-error-formatting/package.json
+++ b/sample/13-transformer-error-formatting/package.json
@@ -1,15 +1,16 @@
 {
-  "name": "nest-trpc-native-sample-05-class-validator",
+  "name": "nest-trpc-native-sample-13-transformer",
   "version": "0.0.0",
   "private": true,
-  "description": "Sample 05 - class-validator and ValidationPipe",
+  "description": "Sample 13 - superjson transformer, error formatting, and response meta",
   "license": "MIT",
   "scripts": {
     "clean": "rimraf dist src/@generated",
     "generate:types": "ts-node --transpile-only src/generate-types.ts",
     "typecheck": "npm run generate:types && tsc --noEmit -p tsconfig.json",
+    "typecheck:client": "npm run generate:types && tsc --noEmit -p tsconfig.client.json",
     "smoke": "npm run generate:types && ts-node --transpile-only scripts/smoke.ts",
-    "test": "npm run typecheck && npm run smoke",
+    "test": "npm run typecheck && npm run typecheck:client && npm run smoke",
     "start": "npm run generate:types && ts-node src/main.ts"
   },
   "dependencies": {
@@ -18,12 +19,12 @@
     "@nestjs/platform-express": "11.1.27",
     "@trpc/client": "^11.18.0",
     "@trpc/server": "^11.16.0",
-    "class-transformer": "0.5.1",
-    "class-validator": "0.15.1",
     "@nest-native/trpc": "0.6.0",
     "reflect-metadata": "0.2.2",
     "rimraf": "6.1.3",
-    "rxjs": "7.8.2"
+    "rxjs": "7.8.2",
+    "superjson": "^2.2.6",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "25.9.3",

--- a/sample/13-transformer-error-formatting/scripts/smoke.ts
+++ b/sample/13-transformer-error-formatting/scripts/smoke.ts
@@ -1,0 +1,82 @@
+import { NestFactory } from '@nestjs/core';
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
+import { AppModule } from '../src/app.module';
+import type { AppRouter } from '../src/@generated/server';
+import { reportedErrors } from '../src/common/observability';
+import { TRPC_PATH } from '../src/common/trpc-context';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function smoke() {
+  const app = await NestFactory.create(AppModule, { logger: false });
+  await app.listen(0, '127.0.0.1');
+
+  try {
+    const baseUrl = await app.getUrl();
+    const client = createTRPCProxyClient<AppRouter>({
+      links: [
+        // The link transformer must match the server's `transformer` option.
+        httpBatchLink({ url: `${baseUrl}${TRPC_PATH}`, transformer: superjson }),
+      ],
+    });
+
+    // 1. superjson round-trips Date instances end to end.
+    const tasks = await client.tasks.list.query();
+    assert(tasks[0]?.dueAt instanceof Date, 'Expected dueAt to be a Date');
+    assert(
+      tasks[0].dueAt.toISOString() === '2026-01-02T03:04:05.000Z',
+      'Expected dueAt to keep its value across the wire',
+    );
+
+    const dueAt = new Date('2027-03-04T05:06:07.000Z');
+    const created = await client.tasks.create.mutate({
+      title: 'Write docs',
+      dueAt,
+    });
+    assert(created.dueAt instanceof Date, 'Expected created.dueAt to be a Date');
+    assert(
+      created.dueAt.getTime() === dueAt.getTime(),
+      'Expected mutation input Date to round-trip',
+    );
+
+    // 2. errorFormatter exposes the flattened ZodError to clients.
+    let zodError: { fieldErrors?: Record<string, string[]> } | undefined;
+    try {
+      await client.tasks.create.mutate({ title: 'x', dueAt });
+    } catch (error) {
+      zodError = (error as { data?: { zodError?: typeof zodError } }).data
+        ?.zodError;
+    }
+    assert(
+      Array.isArray(zodError?.fieldErrors?.title),
+      'Expected flattened ZodError with fieldErrors.title',
+    );
+
+    // 3. onError reported the failing call.
+    assert(
+      reportedErrors.some(
+        entry => entry.path === 'tasks.create' && entry.code === 'BAD_REQUEST',
+      ),
+      'Expected onError to report the failed mutation',
+    );
+
+    // 4. responseMeta adds the cache header to successful queries.
+    const rawResponse = await fetch(`${baseUrl}${TRPC_PATH}/tasks.list`);
+    assert(
+      rawResponse.headers.get('cache-control') === 'public, max-age=60',
+      'Expected responseMeta cache-control header on queries',
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+void smoke().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sample/13-transformer-error-formatting/src/app.module.ts
+++ b/sample/13-transformer-error-formatting/src/app.module.ts
@@ -1,0 +1,52 @@
+import { Module } from '@nestjs/common';
+import { join } from 'path';
+import { TrpcModule } from '@nest-native/trpc';
+import { ZodError, z } from 'zod';
+import superjson from 'superjson';
+import { reportedErrors } from './common/observability';
+import { TRPC_PATH } from './common/trpc-context';
+import { TasksRouter } from './tasks/tasks.router';
+import { TasksService } from './tasks/tasks.service';
+
+@Module({
+  imports: [
+    TrpcModule.forRoot({
+      path: TRPC_PATH,
+      autoSchemaFile: join(process.cwd(), 'src/@generated/server.ts'),
+
+      // Serialize/deserialize with superjson so `Date` (and `Map`, `Set`, ...)
+      // round-trip between server and client. The client must configure the
+      // same transformer on its link (see scripts/smoke.ts).
+      transformer: superjson,
+
+      // Canonical tRPC recipe: expose flattened Zod issues to clients.
+      // Runs after HttpException -> TRPCError mapping, so `error.code`
+      // is already the mapped tRPC code.
+      errorFormatter: ({ shape, error }) => ({
+        ...shape,
+        data: {
+          ...shape.data,
+          zodError:
+            error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+              ? z.flattenError(error.cause)
+              : null,
+        },
+      }),
+
+      // Cache successful queries at the edge; skip streamed (eager) responses.
+      responseMeta: ({ type, errors, eagerGeneration }) => ({
+        headers:
+          type === 'query' && errors.length === 0 && !eagerGeneration
+            ? { 'cache-control': 'public, max-age=60' }
+            : {},
+      }),
+
+      // Centralized error reporting hook.
+      onError: ({ path, error }) => {
+        reportedErrors.push({ path, code: error.code });
+      },
+    }),
+  ],
+  providers: [TasksService, TasksRouter],
+})
+export class AppModule {}

--- a/sample/13-transformer-error-formatting/src/client.typecheck.ts
+++ b/sample/13-transformer-error-formatting/src/client.typecheck.ts
@@ -1,0 +1,26 @@
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
+import type { AppRouter } from './@generated/server';
+
+// The generated AppRouter is marked as transformer-enabled, so the link
+// REQUIRES a `transformer` here — omitting it is a compile-time error.
+const client = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({ url: 'http://localhost:3000/trpc', transformer: superjson }),
+  ],
+});
+
+async function assertTypes() {
+  const tasks = await client.tasks.list.query();
+  // `dueAt` is inferred as a real `Date`, not a string.
+  const _dueAt: Date | undefined = tasks[0]?.dueAt;
+
+  const created = await client.tasks.create.mutate({
+    title: 'Write docs',
+    dueAt: new Date(),
+  });
+  const _createdId: number = created.id;
+  const _createdDueAt: Date = created.dueAt;
+}
+
+void assertTypes;

--- a/sample/13-transformer-error-formatting/src/common/observability.ts
+++ b/sample/13-transformer-error-formatting/src/common/observability.ts
@@ -1,0 +1,6 @@
+/**
+ * In-memory sink for the `onError` hook so the smoke test can assert
+ * that server-side error reporting fired. A real application would
+ * forward these to its logger or error tracker instead.
+ */
+export const reportedErrors: Array<{ path?: string; code: string }> = [];

--- a/sample/13-transformer-error-formatting/src/common/trpc-context.ts
+++ b/sample/13-transformer-error-formatting/src/common/trpc-context.ts
@@ -1,0 +1,1 @@
+export const TRPC_PATH = '/trpc';

--- a/sample/13-transformer-error-formatting/src/generate-types.ts
+++ b/sample/13-transformer-error-formatting/src/generate-types.ts
@@ -1,0 +1,15 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function generateTypes() {
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    abortOnError: false,
+    logger: false,
+  });
+  await app.close();
+}
+
+void generateTypes().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sample/13-transformer-error-formatting/src/main.ts
+++ b/sample/13-transformer-error-formatting/src/main.ts
@@ -1,0 +1,11 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+  console.log(`Application is running on: ${await app.getUrl()}`);
+  console.log(`tRPC endpoint: ${await app.getUrl()}/trpc`);
+}
+
+void bootstrap();

--- a/sample/13-transformer-error-formatting/src/tasks/tasks.router.ts
+++ b/sample/13-transformer-error-formatting/src/tasks/tasks.router.ts
@@ -1,0 +1,20 @@
+import { Input, Mutation, Query, Router } from '@nest-native/trpc';
+import { z } from 'zod';
+import { CreateTaskSchema, TaskSchema } from './tasks.schema';
+import { TasksService } from './tasks.service';
+
+@Router('tasks')
+export class TasksRouter {
+  constructor(private readonly tasksService: TasksService) {}
+
+  @Query({ output: z.array(TaskSchema) })
+  list() {
+    // `dueAt` stays a real `Date` on the wire thanks to superjson.
+    return this.tasksService.list();
+  }
+
+  @Mutation({ input: CreateTaskSchema, output: TaskSchema })
+  create(@Input() input: { title: string; dueAt: Date }) {
+    return this.tasksService.create(input);
+  }
+}

--- a/sample/13-transformer-error-formatting/src/tasks/tasks.schema.ts
+++ b/sample/13-transformer-error-formatting/src/tasks/tasks.schema.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const TaskSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  dueAt: z.date(),
+});
+
+export const CreateTaskSchema = z.object({
+  title: z.string().min(3),
+  dueAt: z.date(),
+});
+
+export type Task = z.infer<typeof TaskSchema>;
+export type CreateTaskInput = z.infer<typeof CreateTaskSchema>;

--- a/sample/13-transformer-error-formatting/src/tasks/tasks.service.ts
+++ b/sample/13-transformer-error-formatting/src/tasks/tasks.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@nestjs/common';
+import { CreateTaskInput, Task } from './tasks.schema';
+
+@Injectable()
+export class TasksService {
+  private readonly tasks: Task[] = [
+    {
+      id: 1,
+      title: 'Ship release',
+      dueAt: new Date('2026-01-02T03:04:05.000Z'),
+    },
+  ];
+  private nextId = 2;
+
+  list() {
+    return [...this.tasks];
+  }
+
+  create(input: CreateTaskInput) {
+    const task = { id: this.nextId++, ...input };
+    this.tasks.push(task);
+    return task;
+  }
+}

--- a/sample/13-transformer-error-formatting/tsconfig.client.json
+++ b/sample/13-transformer-error-formatting/tsconfig.client.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "strict": true
+  },
+  "include": [
+    "src/client.typecheck.ts",
+    "src/@generated/server.ts"
+  ]
+}

--- a/sample/13-transformer-error-formatting/tsconfig.json
+++ b/sample/13-transformer-error-formatting/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ES2021",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "baseUrl": "./",
+    "ignoreDeprecations": "6.0",
+    "types": ["node"],
+    "incremental": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*"]
+}

--- a/sample/README.md
+++ b/sample/README.md
@@ -33,6 +33,7 @@ npm run ci:sample
 | `10-nested-alias-routers` | Dotted aliases as nested router objects | Runnable | `npm run test --workspace nest-trpc-native-sample-10-nested-alias` |
 | `11-microservice-transport` | tRPC gateway + Nest microservice transport (TCP) | Runnable | `npm run test --workspace nest-trpc-native-sample-11-microservice` |
 | `12-angular-fullstack-showcase` | Angular browser client + NestJS backend | Runnable | `npm run test --workspace nest-trpc-native-sample-12-angular-showcase` |
+| `13-transformer-error-formatting` | superjson transformer + `errorFormatter` + `responseMeta` + `onError` | Runnable | `npm run test --workspace nest-trpc-native-sample-13-transformer` |
 
 Use [website/docs/samples/index.md](../website/docs/samples/index.md) for file-level pointers and [website/docs/samples/architecture.md](../website/docs/samples/architecture.md) for structural rationale.
 

--- a/website/docs/advanced/error-handling.md
+++ b/website/docs/advanced/error-handling.md
@@ -61,6 +61,39 @@ create(@Input() input: CreateUserDto) {
 }
 ```
 
+## Custom Error Shapes with `errorFormatter`
+
+To change the *shape* of the error payload sent to clients (rather than which error is thrown), configure `errorFormatter` on the module. It is forwarded to `initTRPC.create({ errorFormatter })` and runs **after** the `HttpException` → `TRPCError` mapping above, so `error.code` is already the mapped tRPC code:
+
+```ts
+import { z, ZodError } from 'zod';
+
+TrpcModule.forRoot({
+  errorFormatter: ({ shape, error }) => ({
+    ...shape,
+    data: {
+      ...shape.data,
+      zodError:
+        error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+          ? z.flattenError(error.cause)
+          : null,
+    },
+  }),
+});
+```
+
+Clients read the extra fields from `error.data` (e.g. `error.data.zodError.fieldErrors`). Combine with `onError` for centralized reporting:
+
+```ts
+TrpcModule.forRoot({
+  onError: ({ error, path, type }) => {
+    logger.error(`tRPC ${type} "${path}" failed: ${error.code}`);
+  },
+});
+```
+
+See [`sample/13-transformer-error-formatting`](https://github.com/nest-native/trpc/tree/main/sample/13-transformer-error-formatting) for the runnable recipe.
+
 ## Custom Application Codes (Idiomatic Pattern)
 
 tRPC transport codes are fixed. For app-specific codes, keep a stable transport code and add a domain code in the message.
@@ -126,3 +159,4 @@ Reference tests:
 
 - `packages/trpc/test/context/trpc-context-creator.spec.ts`
 - `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`
+- `packages/trpc/test/adapter/trpc-http-adapter.spec.ts` (errorFormatter and onError passthrough)

--- a/website/docs/client-consumption.md
+++ b/website/docs/client-consumption.md
@@ -43,6 +43,24 @@ const users = await trpc.users.list.query();
 const created = await trpc.users.create.mutate({ name: 'Ada' });
 ```
 
+## Match the Server's Transformer
+
+If the server configures a [data transformer](./module-setup/for-root#with-a-data-transformer) (`TrpcModule.forRoot({ transformer: superjson })`), every client link must configure the **same** transformer:
+
+```ts
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
+import type { AppRouter } from './@generated/server';
+
+export const trpc = createTRPCProxyClient<AppRouter>({
+  links: [
+    httpBatchLink({ url: 'http://localhost:3000/trpc', transformer: superjson }),
+  ],
+});
+```
+
+The generated `AppRouter` marks the router as transformer-enabled, so forgetting the link transformer is a compile-time error, and transformed values such as `Date` are typed (and delivered) as real `Date` instances.
+
 ## Share Types In A Monorepo
 
 In a monorepo, prefer one shared type export rather than deep imports between apps:

--- a/website/docs/decorators/subscription.md
+++ b/website/docs/decorators/subscription.md
@@ -4,18 +4,11 @@ sidebar_position: 3
 
 # @Subscription()
 
-The `@Subscription()` decorator defines a tRPC subscription procedure for real-time data streaming.
+The `@Subscription()` decorator defines a tRPC subscription procedure for real-time data streaming over **Server-Sent Events (SSE)** — tRPC v11's recommended default transport.
 
-## Both Patterns Work
+## Supported Shape: Async Generators
 
-`@nest-native/trpc` supports both tRPC subscription return styles:
-
-- async generators (`async function*`) - recommended default
-- `observable()` from `@trpc/server/observable` - fully supported
-
-## Async Generators (Recommended)
-
-tRPC v11 recommends **async generators** for subscriptions. This is the pattern used throughout the samples:
+Subscription handlers must return an async iterable. In practice that means writing the handler as an **async generator** (`async function*`), the pattern used throughout the samples:
 
 ```ts
 import { Input, Router, Subscription, TrpcContext } from '@nest-native/trpc';
@@ -39,11 +32,11 @@ class EventsRouter {
 }
 ```
 
-Async generators are simpler, naturally support backpressure, and work seamlessly with `@Input()` and `@TrpcContext()` decorators.
+Async generators are simple, naturally support backpressure, and work seamlessly with `@Input()` and `@TrpcContext()` decorators. A handler may also return any object implementing `Symbol.asyncIterator`; each yielded value is validated against the `output` schema when one is configured. A non-iterable return value is emitted once and the subscription completes.
 
 ## Client Usage
 
-Subscriptions use SSE by default in tRPC v11:
+Subscriptions stream over SSE via `httpSubscriptionLink`:
 
 ```ts
 import { createTRPCProxyClient, splitLink, httpBatchLink, httpSubscriptionLink } from '@trpc/client';
@@ -71,44 +64,30 @@ const subscription = client.ticks.subscribe(
 subscription.unsubscribe();
 ```
 
-## Observable Pattern (Also Supported)
+## Not Supported: `observable()` Returns
 
-Use `observable()` when you prefer push-style emission/teardown semantics:
+tRPC's legacy `observable()` helper (from `@trpc/server/observable`) is **not supported** as a subscription return value. The subscription wrapper streams async iterables only; an `observable()` return value would be emitted once as a plain object instead of streaming its events.
+
+If you have push-style sources (`EventEmitter`, message queues, RxJS), bridge them into an async generator. For example, with Node's `events.on`:
 
 ```ts
-import { Input, Router, Subscription, TrpcContext } from '@nest-native/trpc';
-import { observable } from '@trpc/server/observable';
-import { z } from 'zod';
+import { EventEmitter, on } from 'events';
 
-const TickInputSchema = z.object({ count: z.number().optional() });
+const emitter = new EventEmitter();
 
-@Router('cats')
-class CatsRouter {
-  @Subscription({ input: TickInputSchema })
-  ticks(
-    @Input('count') count: number | undefined,
-    @TrpcContext('requestId') requestId: string,
-  ) {
-    return observable((emit) => {
-      let tick = 0;
-      const total = count ?? 3;
-      const interval = setInterval(() => {
-        tick += 1;
-        emit.next({ tick, requestId });
-        if (tick >= total) {
-          clearInterval(interval);
-          emit.complete();
-        }
-      }, 300);
-
-      return () => clearInterval(interval);
-    });
+@Router()
+class NotificationsRouter {
+  @Subscription()
+  async *notifications() {
+    for await (const [payload] of on(emitter, 'notification')) {
+      yield payload;
+    }
   }
 }
 ```
 
-Use whichever model matches your team style. For new code, async generators are typically easier to read and test.
+## Transport
 
-:::info Transport
-Subscriptions use **Server-Sent Events (SSE)** by default in tRPC v11 via `httpSubscriptionLink`. WebSocket transport is also available. See the [tRPC subscriptions docs](https://trpc.io/docs/subscriptions) for transport options.
+:::info SSE only
+Subscriptions are served over **Server-Sent Events (SSE)** via `httpSubscriptionLink` — tRPC v11's recommended default for subscriptions. WebSocket transport (`wsLink` / `applyWSSHandler`) is **not provided** by `@nest-native/trpc` and is currently a non-goal. See the [tRPC subscriptions docs](https://trpc.io/docs/subscriptions) for background on the transports tRPC itself defines.
 :::

--- a/website/docs/module-setup/for-root.md
+++ b/website/docs/module-setup/for-root.md
@@ -29,6 +29,10 @@ export class AppModule {}
 | `path` | `string` | The HTTP path where tRPC procedures are served (e.g. `'/trpc'`) |
 | `autoSchemaFile` | `string` | Path for auto-generated `AppRouter` type file |
 | `createContext` | `(opts) => TContext` | Factory function to create tRPC context per request |
+| `transformer` | `DataTransformer` | tRPC data transformer (e.g. `superjson`), forwarded to `initTRPC.create({ transformer })` |
+| `errorFormatter` | `TRPCErrorFormatter` | Custom error shape, forwarded to `initTRPC.create({ errorFormatter })` |
+| `responseMeta` | `ResponseMetaFn` | Per-response HTTP status/headers hook (e.g. `Cache-Control`), forwarded to the tRPC request handler |
+| `onError` | `HTTPErrorHandler` | Centralized error logging/reporting hook, forwarded to the tRPC request handler |
 
 ## With Schema Generation
 
@@ -54,3 +58,78 @@ TrpcModule.forRoot({
 ```
 
 See [Typed Context](./typed-context) for compile-time type safety on the context factory.
+
+## With a Data Transformer
+
+Pass a tRPC [data transformer](https://trpc.io/docs/server/data-transformers) such as `superjson` so values like `Date`, `Map`, and `Set` round-trip between server and client:
+
+```ts
+import superjson from 'superjson';
+
+TrpcModule.forRoot({
+  path: '/trpc',
+  autoSchemaFile: 'src/@generated/server.ts',
+  transformer: superjson,
+});
+```
+
+The client must configure the **same** transformer on its terminating link:
+
+```ts
+import { createTRPCProxyClient, httpBatchLink } from '@trpc/client';
+import superjson from 'superjson';
+import type { AppRouter } from './@generated/server';
+
+const client = createTRPCProxyClient<AppRouter>({
+  links: [httpBatchLink({ url: 'http://localhost:3000/trpc', transformer: superjson })],
+});
+```
+
+When `transformer` and `autoSchemaFile` are combined, the generated `AppRouter` type is marked transformer-enabled, so typed clients get a **compile-time error** if they forget the link transformer, and transformed outputs such as `Date` are inferred as `Date` rather than `string`.
+
+## With an Error Formatter
+
+Use `errorFormatter` to reshape the error payload sent to clients. It runs **after** the built-in `HttpException` → `TRPCError` mapping, so `error.code` is already the mapped tRPC code. The canonical recipe exposes flattened Zod issues:
+
+```ts
+import { z, ZodError } from 'zod';
+
+TrpcModule.forRoot({
+  path: '/trpc',
+  errorFormatter: ({ shape, error }) => ({
+    ...shape,
+    data: {
+      ...shape.data,
+      zodError:
+        error.code === 'BAD_REQUEST' && error.cause instanceof ZodError
+          ? z.flattenError(error.cause)
+          : null,
+    },
+  }),
+});
+```
+
+Clients then read `error.data.zodError.fieldErrors` to render per-field messages.
+
+## With Response Meta and Error Reporting
+
+`responseMeta` sets per-response HTTP status/headers (the standard place for `Cache-Control`), and `onError` is the centralized hook for logging and reporting failures:
+
+```ts
+TrpcModule.forRoot({
+  path: '/trpc',
+  responseMeta: ({ type, errors, eagerGeneration }) => ({
+    headers:
+      type === 'query' && errors.length === 0 && !eagerGeneration
+        ? { 'cache-control': 'public, max-age=60' }
+        : {},
+  }),
+  onError: ({ error, path }) => {
+    console.error(`tRPC error on "${path}": ${error.message}`);
+  },
+});
+```
+
+`responseMeta` headers are applied to both JSON responses and streamed SSE subscription responses. For SSE, the hook runs eagerly (`eagerGeneration: true`) before the first chunk is written, so a returned `status` cannot rewrite an already-streaming response.
+
+All four options are forwarded to tRPC untouched and add no runtime dependencies to the package. See [`sample/13-transformer-error-formatting`](https://github.com/nest-native/trpc/tree/main/sample/13-transformer-error-formatting) for a runnable demonstration.

--- a/website/docs/module-setup/typed-context.md
+++ b/website/docs/module-setup/typed-context.md
@@ -43,8 +43,14 @@ export interface TrpcModuleOptions<TContext = any> {
   path?: string;
   autoSchemaFile?: string;
   createContext?: (opts: { req: any; res: any }) => TContext | Promise<TContext>;
+  transformer?: DataTransformer | CombinedDataTransformer;
+  errorFormatter?: TRPCErrorFormatter<TContext, TRPCErrorShape>;
+  responseMeta?: ResponseMetaFn<AnyRouter>;
+  onError?: HTTPErrorHandler<AnyRouter, Request>;
 }
 ```
+
+The `errorFormatter` option also receives `TContext`, so a typed context flows into `ctx` inside the formatter.
 
 ## Backward Compatibility
 

--- a/website/docs/reference/claims-matrix.md
+++ b/website/docs/reference/claims-matrix.md
@@ -16,6 +16,12 @@ This page maps the main public claims to current verification evidence. It is a 
 | `@Input()` supports full input and field extraction. | `packages/trpc/test/context/trpc-context-creator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `website/docs/decorators/input.md` | Covered by package tests and docs. |
 | `@TrpcContext()` supports full context and field extraction. | `packages/trpc/test/context/trpc-context-creator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/03-context-request-scope` | Covered by package tests and samples. |
 | `autoSchemaFile` generates importable `AppRouter` types. | `packages/trpc/test/generators/schema-generator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/08-autoschema-client-typecheck/src/client.typecheck.ts` | Covered by package tests and client typecheck sample. |
+| `transformer` (e.g. superjson) round-trips `Date` values between server and client. | `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/13-transformer-error-formatting`, `website/docs/module-setup/for-root.md` | Covered by package E2E tests and samples. |
+| `autoSchemaFile` + `transformer` marks the generated `AppRouter` so typed clients must configure a link transformer. | `packages/trpc/test/generators/schema-generator.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts`, `sample/13-transformer-error-formatting/src/client.typecheck.ts` | Covered by package tests (including a negative typecheck) and sample typecheck. |
+| `errorFormatter` reshapes errors after `HttpException` → `TRPCError` mapping (flattened-ZodError recipe). | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `sample/13-transformer-error-formatting`, `website/docs/advanced/error-handling.md` | Covered by package tests and samples. |
+| `responseMeta` sets response status/headers on JSON and SSE responses. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/13-transformer-error-formatting/scripts/smoke.ts` | Covered by package tests (both paths) and sample smoke. |
+| `onError` is invoked for failing procedures. | `packages/trpc/test/adapter/trpc-http-adapter.spec.ts`, `sample/13-transformer-error-formatting/scripts/smoke.ts` | Covered by package tests and sample smoke. |
+| Subscriptions stream async generators over SSE; `observable()` returns and WebSocket transport are not supported. | `packages/trpc/trpc-router.ts` (`createSubscriptionProcedure`), `packages/trpc/test/adapter/trpc-client-adapter-e2e.spec.ts`, `website/docs/decorators/subscription.md` | Documented limitation; streaming behavior covered by package tests. |
 | `TrpcRouter` is supported for in-process testing. | `website/docs/testing/router-testing.md`, `packages/trpc/test/router/trpc-router.spec.ts`, `packages/trpc/test/router/trpc-router-lifecycle.spec.ts` | Covered as advanced testing API. |
 | Invalid router aliases and duplicate procedure paths fail with actionable diagnostics. | `packages/trpc/test/router/trpc-router.spec.ts` | Covered by package tests. |
 
@@ -64,6 +70,8 @@ These gaps should guide future PRs:
 Do not make these claims unless new code, docs, and tests are added:
 
 - "Official NestJS integration."
+- "WebSocket subscription transport is available." Subscriptions are SSE-only (`httpSubscriptionLink`); no `wsLink`/`applyWSSHandler` integration exists.
+- "tRPC `observable()` subscriptions are supported." The subscription wrapper streams async iterables only; `observable()` return values do not stream.
 - "Production security is handled by the library." Authentication, authorization, rate limiting, CORS, and secret handling are application responsibilities. See [Security Responsibilities](../advanced/security-responsibilities).
 - "Benchmarked faster than REST, GraphQL, or vanilla tRPC."
 - "All package internals are stable extension points."

--- a/website/docs/samples/catalog.md
+++ b/website/docs/samples/catalog.md
@@ -21,6 +21,7 @@ sidebar_position: 2
 | `sample/10-nested-alias-routers` | Dotted aliases mapped to nested routers | `npm run test --workspace nest-trpc-native-sample-10-nested-alias` |
 | `sample/11-microservice-transport` | tRPC gateway with Nest microservice transport (TCP) | `npm run test --workspace nest-trpc-native-sample-11-microservice` |
 | `sample/12-angular-fullstack-showcase` | Angular browser client + NestJS backend | `npm run test --workspace nest-trpc-native-sample-12-angular-showcase` |
+| `sample/13-transformer-error-formatting` | superjson transformer, `errorFormatter`, `responseMeta`, `onError` | `npm run test --workspace nest-trpc-native-sample-13-transformer` |
 
 ## GitHub Folders
 
@@ -37,3 +38,4 @@ sidebar_position: 2
 - [10-nested-alias-routers](https://github.com/nest-native/trpc/tree/main/sample/10-nested-alias-routers)
 - [11-microservice-transport](https://github.com/nest-native/trpc/tree/main/sample/11-microservice-transport)
 - [12-angular-fullstack-showcase](https://github.com/nest-native/trpc/tree/main/sample/12-angular-fullstack-showcase)
+- [13-transformer-error-formatting](https://github.com/nest-native/trpc/tree/main/sample/13-transformer-error-formatting)

--- a/website/docs/samples/how-to-review.md
+++ b/website/docs/samples/how-to-review.md
@@ -94,6 +94,7 @@ For targeted review, run the focused sample that matches the change:
 | Nested aliases | `npm run test --workspace nest-trpc-native-sample-10-nested-alias` |
 | Microservice transport bridge | `npm run test --workspace nest-trpc-native-sample-11-microservice` |
 | Angular browser showcase | `npm run test --workspace nest-trpc-native-sample-12-angular-showcase` |
+| Transformer, error formatting, response meta | `npm run test --workspace nest-trpc-native-sample-13-transformer` |
 
 ## Docs Review
 


### PR DESCRIPTION
## What

Exposes four tRPC v11 server capabilities that were previously unreachable because the library owns the server config internally, and fixes the subscription documentation overclaims. Releases as **0.6.0**.

### Server-config passthrough (`TrpcModuleOptions`)

| Option | Threaded into | Purpose |
| --- | --- | --- |
| `transformer` | `initTRPC.create({ transformer })` (`trpc-router.ts`) | superjson-style serialization so `Date`/`Map` round-trip |
| `errorFormatter` | `initTRPC.create({ errorFormatter })` (`trpc-router.ts`) | custom error shapes, e.g. the canonical flattened-ZodError recipe |
| `responseMeta` | `fetchRequestHandler` opts (`trpc-http-adapter.ts`) | per-response status/headers (e.g. `Cache-Control`) |
| `onError` | `fetchRequestHandler` opts (`trpc-http-adapter.ts`) | centralized error logging/reporting hook |

All four are typed from `@trpc/server`'s own types (type-only imports; `dependencies` stays `{}`), and forwarded untouched.

### Generated-client honesty for `transformer`

tRPC v11 typed clients require the router type to know whether a transformer is in play (`httpBatchLink` demands `transformer` iff the router's `$types.transformer` is `true`). When `autoSchemaFile` + `transformer` are combined, the generated `AppRouter` now emits a type-level transformer marker, so:

- omitting the link transformer on a typed client is a **compile-time error** (covered by a negative-typecheck test);
- transformed outputs such as `Date` are inferred as `Date` instead of `Serialize<>`-mangled `string`.

### Behavior verified by tests (100% coverage held)

- superjson round-trips `Date` through queries, mutation inputs/outputs, and SSE subscriptions via the real `@trpc/client` on Express and Fastify.
- `errorFormatter` composes **after** the `HttpException` → `TRPCError` mapping (a mapped `BAD_REQUEST` is reshaped with `data.custom`), and the flattened-ZodError recipe (`z.flattenError(error.cause)`) reaches clients as `error.data.zodError`.
- `responseMeta` headers are applied on the JSON path (with status override) **and** on the SSE path before streaming starts (`eagerGeneration: true`; tRPC appends to its own `no-cache, no-transform`).
- `onError` fires with the mapped code and procedure path.

### Subscription docs honesty fix

`website/docs/decorators/subscription.md` claimed `observable()` was "fully supported" and WebSocket transport "available" — neither is true (the subscription wrapper streams `Symbol.asyncIterator` shapes only; no WS code exists). Rewritten SSE-first: async generators are the supported shape, `observable()` is explicitly unsupported (with an async-generator bridge example), WS is an explicit non-goal. Claims matrix updated with new verified rows and unsupported-claim entries; `sample/06-subscriptions/README.md` corrected.

### New sample

`sample/13-transformer-error-formatting` — superjson + ZodError-flattening errorFormatter + `Cache-Control` via `responseMeta` + `onError` reporting, with typecheck (`transformer` required by generated types), client typecheck, and smoke per sample conventions.

## Release

- `packages/trpc` → **0.6.0**; all `sample/*/package.json` pins → `0.6.0`; CHANGELOG entry added.
- No new runtime dependencies (superjson is a root devDep + sample dep only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
