### PR TITLE
docs: add CLAUDE.md importing the guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+@GUIDELINES_NEST_TRPC.md
+
+The imported guidelines are binding. Two always-on rules:
+- Stryker mutation testing is local-only — never wire it into CI.
+- Pre-PR ritual: `npm run test:mutation` (scope with `STRYKER_MUTATE` to changed files) and report surviving mutants in the PR body.


### PR DESCRIPTION
Adds a committed `CLAUDE.md` that `@`-imports [`GUIDELINES_NEST_TRPC.md`](GUIDELINES_NEST_TRPC.md) so the project guidelines are binding for AI coding agents, and restates the two always-on rules:

- Stryker mutation testing is local-only — never wired into CI.
- Pre-PR ritual: `npm run test:mutation` (scope with `STRYKER_MUTATE` to changed files), reporting surviving mutants in the PR body.

Docs-only. No source, no CI, no `.github/` changes.