### PR TITLE
test: kill generator/param-metadata mutation survivors; reframe mutation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- Tests + internal: closed the mutation-testing survivors surfaced in the
+  generators and param metadata — added a `param-metadata` guard test (an
+  `undefined` propertyKey must not attach metadata to a property literally named
+  `"undefined"`), plus generator/serializer/module/constants specs. Simplified
+  three equivalent-mutant branches (dropped a redundant `'utf-8'` write
+  encoding and an unused indent variable in the schema generator; folded the
+  `any`/`lazy`/`nativeEnum` cases into the shared `z.any()` fallback in the zod
+  serializer). Behavior-neutral, 100% coverage. Docs: reframed mutation-testing
+  guidance as an occasional, scoped audit (not a per-PR gate).
 - Stryker mutation testing (repo tooling; nothing ships in the package):
   `npm run test:mutation` (incremental) / `npm run test:mutation:full`, with
   `STRYKER_MUTATE` scoping (comma-separated globs). Opt-in and local-only —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,4 @@
 
 The imported guidelines are binding. Two always-on rules:
 - Stryker mutation testing is local-only — never wire it into CI.
-- Pre-PR ritual: `npm run test:mutation` (scope with `STRYKER_MUTATE` to changed files) and report surviving mutants in the PR body.
+- Mutation testing is an **occasional, targeted audit — not a per-PR gate**. Run it deliberately when you've reworked a file's logic: scope with `STRYKER_MUTATE` to that one file, `--concurrency 2`, and verify a kill by hand-applying the mutation + running the plain suite (see the guidelines' Mutation testing section).

--- a/GUIDELINES_NEST_TRPC.md
+++ b/GUIDELINES_NEST_TRPC.md
@@ -143,21 +143,37 @@ Required post-publish checklist:
 - Treat the PR complexity report as a review signal for deltas and hotspots, not an automatic refactor mandate.
 - Do not reduce complexity by weakening Nest-native architecture, public API clarity, validation behavior, or test coverage.
 
-### 11. Mutation testing (Stryker — local only, never in CI)
+### 11. Mutation testing (Stryker — occasional targeted audit, local only, never in CI)
 
-Everything here is **opt-in and local-only**. Plain `npm test` and CI are
-unchanged; forks work out of the box. **CI never runs mutation testing** — it
-is an on-demand, local-only gate.
+Mutation testing here is an **occasional, targeted audit — not a per-PR gate**.
+Run it deliberately when you've written or reworked non-trivial logic in a file
+and want to know whether its tests actually pin the behavior. It has found real
+gaps here (a param-metadata `propertyKey` guard, redundant serializer branches),
+so it is worth doing — occasionally and precisely. Plain `npm test` and CI are
+unchanged; **CI never runs mutation testing.**
 
-- `npm run test:mutation` — **incremental** run (cache:
-  `reports/stryker-incremental.json`; only re-tests what changed). This is the
-  pre-PR ritual for changes to package source.
-- `npm run test:mutation:full` — every mutant from scratch (`--force`).
-- `STRYKER_MUTATE='packages/trpc/generators/**,packages/trpc/trpc-router.ts'` —
-  comma-separated globs to scope a run to the files a change touched.
-- Report: `reports/mutation/mutation.html`. Thresholds are advisory
-  (`break: null`) — the signal is *which mutants survive*, not the score.
+**Run it scoped, never full-package.** The command runner re-runs the whole
+suite per mutant, so a full run is slow and a large surface can time out. Scope
+to the one file you changed:
 
-Pre-PR ritual: run `npm run test:mutation` (scope with `STRYKER_MUTATE` when
-the change is small), look at surviving mutants, and mention the outcome in
-the PR body. Keep CI fast — that is a deliberate contract.
+- `STRYKER_MUTATE='packages/trpc/generators/zod-serializer.ts' npx stryker run --concurrency 2`
+  — low concurrency keeps RAM in check and avoids the CPU oversubscription that
+  turns kills into timeouts. Read survivors from
+  `reports/stryker-incremental.json` or `reports/mutation/mutation.html`.
+- `npm run test:mutation` / `test:mutation:full` remain for incremental / full
+  passes; expect them to be slow on a large surface.
+
+**Verify a kill without re-running Stryker — the fast path.** Hand-apply the
+surviving mutation to the source, run the plain suite (or just the one spec),
+confirm your new test fails, then `git checkout --` to revert. This decouples
+the slow "find survivors" step from a fast "prove the kill" step.
+
+**If a run times out, kill the leftovers first** — a killed Stryker command can
+leave detached test processes that starve the next run; `pgrep -f stryker`,
+`kill -9`, confirm RAM recovered, then retry.
+
+Treat each survivor by the doctrine: add a test that kills it; simplify
+redundant code whose mutant is behaviorally equivalent (with a CHANGELOG note);
+mark a genuine equivalent with `// Stryker disable next-line <Mutator>:
+<reason>`; or, for timing/randomness, assert bounds/progression. Keep CI fast —
+that is a deliberate contract.

--- a/packages/trpc/generators/schema-generator.ts
+++ b/packages/trpc/generators/schema-generator.ts
@@ -46,7 +46,8 @@ export function generateSchema(
 ): void {
   const content = generateSchemaContent(routers, options);
   mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, content, 'utf-8');
+  // utf-8 is Node's default encoding for string data.
+  writeFileSync(filePath, content);
 }
 
 /**
@@ -196,7 +197,6 @@ function renderNestedMapEntries(
   depth: number,
 ): string[] {
   const indent = '  '.repeat(depth);
-  const childIndent = '  '.repeat(depth + 1);
   const entries: string[] = [];
 
   for (const [key, value] of Object.entries(node)) {

--- a/packages/trpc/generators/zod-serializer.ts
+++ b/packages/trpc/generators/zod-serializer.ts
@@ -30,8 +30,6 @@ export function serializeZodSchema(schema: any): string {
       return 'z.null()';
     case 'void':
       return 'z.void()';
-    case 'any':
-      return 'z.any()';
     case 'unknown':
       return 'z.unknown()';
     case 'never':
@@ -129,10 +127,6 @@ export function serializeZodSchema(schema: any): string {
       // The effect itself is runtime-only and doesn't affect the type used for inference.
       return serializeZodSchema(schema._def.schema);
 
-    case 'lazy':
-      // Lazy schemas can't be serialized; fall back.
-      return 'z.any()';
-
     case 'pipeline':
     case 'pipe':
       // For type inference, use the output schema.
@@ -156,11 +150,10 @@ export function serializeZodSchema(schema: any): string {
     case 'readonly':
       return `${serializeZodSchema(schema._def.innerType)}.readonly()`;
 
-    case 'nativeEnum':
-      // Native enums reference runtime values that can't be reconstructed.
-      return 'z.any()';
-
     default:
+      // Intentional z.any() fallbacks share this branch: 'any' itself,
+      // 'lazy' (cannot be serialized), 'nativeEnum' (references runtime
+      // values that cannot be reconstructed), and any unknown type.
       return 'z.any()';
   }
 }

--- a/packages/trpc/test/constants.spec.ts
+++ b/packages/trpc/test/constants.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import {
+  TRPC_INPUT_METADATA,
+  TRPC_MODULE_OPTIONS,
+  TRPC_OUTPUT_METADATA,
+  TRPC_PARAM_ARGS_METADATA,
+  TRPC_PROCEDURE_METADATA,
+  TRPC_PROCEDURE_TYPE_METADATA,
+  TRPC_ROUTER_METADATA,
+} from '../constants';
+
+/**
+ * The metadata keys are a wire-level contract: decorators write them onto
+ * user classes/methods via `Reflect.defineMetadata`, so they are observable
+ * to devtools and must stay unique and stable across package versions
+ * (e.g. when two copies of the library coexist in one dependency tree).
+ */
+describe('constants (metadata-key contract)', () => {
+  it('should keep the documented metadata key values', () => {
+    expect(TRPC_MODULE_OPTIONS).to.equal('TRPC_MODULE_OPTIONS');
+    expect(TRPC_ROUTER_METADATA).to.equal('trpc:router');
+    expect(TRPC_PROCEDURE_METADATA).to.equal('trpc:procedure');
+    expect(TRPC_PROCEDURE_TYPE_METADATA).to.equal('trpc:procedure_type');
+    expect(TRPC_INPUT_METADATA).to.equal('trpc:input');
+    expect(TRPC_OUTPUT_METADATA).to.equal('trpc:output');
+    expect(TRPC_PARAM_ARGS_METADATA).to.equal('__trpcParamArgs__');
+  });
+
+  it('should keep all metadata keys unique', () => {
+    const keys = [
+      TRPC_MODULE_OPTIONS,
+      TRPC_ROUTER_METADATA,
+      TRPC_PROCEDURE_METADATA,
+      TRPC_PROCEDURE_TYPE_METADATA,
+      TRPC_INPUT_METADATA,
+      TRPC_OUTPUT_METADATA,
+      TRPC_PARAM_ARGS_METADATA,
+    ];
+    expect(new Set(keys).size).to.equal(keys.length);
+  });
+});

--- a/packages/trpc/test/decorators/decorators.spec.ts
+++ b/packages/trpc/test/decorators/decorators.spec.ts
@@ -112,6 +112,23 @@ describe('tRPC Decorators', () => {
       expect(outputMeta).to.equal(schema);
     });
 
+    it('should not define input/output metadata keys when no schemas are provided', () => {
+      class TestRouter {
+        @Query()
+        getAll() {
+          return [];
+        }
+      }
+
+      const instance = new TestRouter();
+      expect(
+        Reflect.hasOwnMetadata(TRPC_INPUT_METADATA, instance.getAll),
+      ).to.equal(false);
+      expect(
+        Reflect.hasOwnMetadata(TRPC_OUTPUT_METADATA, instance.getAll),
+      ).to.equal(false);
+    });
+
     it('should accept name and options together', () => {
       const inputSchema = z.object({ id: z.number() });
 

--- a/packages/trpc/test/decorators/param-metadata.util.spec.ts
+++ b/packages/trpc/test/decorators/param-metadata.util.spec.ts
@@ -12,6 +12,17 @@ describe('addTrpcParamMetadata', () => {
     expect(Reflect.getMetadataKeys(target)).to.have.length(0);
   });
 
+  it('should not fall through to a property literally named "undefined" when propertyKey is undefined', () => {
+    // Without the propertyKey guard, `target[propertyKey]` would coerce the
+    // undefined key to the string "undefined" and attach metadata to this fn.
+    const fn = () => {};
+    const target = { undefined: fn };
+    addTrpcParamMetadata(target, undefined, 0, TrpcParamtype.INPUT);
+    expect(Reflect.getMetadata(TRPC_PARAM_ARGS_METADATA, fn)).to.equal(
+      undefined,
+    );
+  });
+
   it('should do nothing when target[propertyKey] is not a function', () => {
     const target: Record<string, any> = { myProp: 'not-a-function' };
     addTrpcParamMetadata(target, 'myProp', 0, TrpcParamtype.INPUT);

--- a/packages/trpc/test/generators/schema-generator.spec.ts
+++ b/packages/trpc/test/generators/schema-generator.spec.ts
@@ -189,6 +189,103 @@ describe('generateSchemaContent', () => {
     expect(listProcedureOccurrences).to.have.length(2);
   });
 
+  it('should import zod when only some routers/procedures declare schemas', () => {
+    const routers: RouterInfo[] = [
+      {
+        alias: 'mixed',
+        procedures: [
+          {
+            name: 'withSchema',
+            type: ProcedureType.QUERY,
+            inputSchema: z.object({ id: z.string() }),
+          },
+          { name: 'withoutSchema', type: ProcedureType.QUERY },
+        ],
+      },
+      {
+        alias: 'plain',
+        procedures: [{ name: 'noSchema', type: ProcedureType.QUERY }],
+      },
+    ];
+
+    const content = generateSchemaContent(routers);
+
+    expect(content).to.include("import { z } from 'zod';");
+  });
+
+  it('should replace a conflicting router alias when a dotted alias claims it as a namespace', () => {
+    // TrpcRouter rejects this configuration at registration time; when
+    // generateSchemaContent is fed it directly, the namespace wins and the
+    // generator must not crash.
+    const routers: RouterInfo[] = [
+      {
+        alias: 'pay',
+        procedures: [{ name: 'charge', type: ProcedureType.QUERY }],
+      },
+      {
+        alias: 'pay.methods',
+        procedures: [{ name: 'list', type: ProcedureType.QUERY }],
+      },
+    ];
+
+    const content = generateSchemaContent(routers);
+
+    expect(content).to.include('pay: {');
+    expect(content).to.include('methods: t.router({');
+    expect(content).to.not.include('pay: t.router({');
+  });
+
+  it('should keep nested and multi-procedure formatting stable without schemas', () => {
+    const routers: RouterInfo[] = [
+      {
+        alias: 'billing',
+        procedures: [
+          { name: 'invoice', type: ProcedureType.QUERY },
+          { name: 'refund', type: ProcedureType.MUTATION },
+        ],
+      },
+      {
+        alias: 'admin.users',
+        procedures: [{ name: 'list', type: ProcedureType.QUERY }],
+      },
+      {
+        alias: 'admin.roles',
+        procedures: [{ name: 'list', type: ProcedureType.QUERY }],
+      },
+    ];
+
+    expect(generateSchemaContent(routers)).to.equal(
+      [
+        '// ------------------------------------------------------',
+        '// THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)',
+        '// @nest-native/trpc',
+        '// ------------------------------------------------------',
+        '',
+        "import { initTRPC } from '@trpc/server';",
+        '',
+        'const t = initTRPC.create();',
+        '',
+        'const appRouter = t.router({',
+        '  billing: t.router({',
+        '    invoice: t.procedure.query(() => undefined as unknown),',
+        '    refund: t.procedure.mutation(() => undefined as unknown),',
+        '  }),',
+        '  admin: {',
+        '    users: t.router({',
+        '    list: t.procedure.query(() => undefined as unknown),',
+        '  }),',
+        '    roles: t.router({',
+        '    list: t.procedure.query(() => undefined as unknown),',
+        '  })',
+        '  }',
+        '});',
+        '',
+        'export type AppRouter = typeof appRouter;',
+        '',
+      ].join('\n'),
+    );
+  });
+
   it('should ignore dotted aliases that normalize to empty segments', () => {
     const routers: RouterInfo[] = [
       {
@@ -240,6 +337,38 @@ describe('generateSchemaContent', () => {
     );
   });
 
+  it('should sanitize non-identifier characters to underscores and keep inner digits unprefixed', () => {
+    const routers: RouterInfo[] = [
+      {
+        alias: 'user-profile',
+        procedures: [
+          {
+            name: 'get',
+            type: ProcedureType.QUERY,
+            inputSchema: z.object({ id: z.string() }),
+          },
+        ],
+      },
+      {
+        alias: 'v2',
+        procedures: [
+          {
+            name: 'list',
+            type: ProcedureType.QUERY,
+            inputSchema: z.object({ limit: z.number() }),
+          },
+        ],
+      },
+    ];
+
+    const content = generateSchemaContent(routers);
+
+    // '-' becomes '_' (not stripped)
+    expect(content).to.include('const schema_user_profile_get_input_0 =');
+    // digits that are not leading get no '_' prefix
+    expect(content).to.include('const schema_v2_list_input_1 =');
+  });
+
   it('should emit a bare initTRPC.create() when hasTransformer is false', () => {
     const content = generateSchemaContent(
       [{ procedures: [{ name: 'ping', type: ProcedureType.QUERY }] }],
@@ -261,6 +390,17 @@ describe('generateSchemaContent', () => {
     expect(content).to.include('  deserialize: (value: unknown) => value,');
     expect(content).to.include('const t = initTRPC.create({ transformer });');
     expect(content).to.not.include('const t = initTRPC.create();');
+    // The explanatory comments are part of the generated-file contract:
+    // they tell users why the marker exists and what their client needs.
+    expect(content).to.include(
+      '// Type-level marker mirroring the transformer configured on the server.',
+    );
+    expect(content).to.include(
+      '// Clients must configure the matching transformer on their link,',
+    );
+    expect(content).to.include(
+      '// e.g. httpBatchLink({ url, transformer: superjson }).',
+    );
   });
 
   it('should keep generated schema formatting stable', () => {

--- a/packages/trpc/test/generators/zod-serializer.spec.ts
+++ b/packages/trpc/test/generators/zod-serializer.spec.ts
@@ -165,7 +165,12 @@ describe('serializeZodSchema', () => {
       },
     };
 
-    expect(serializeZodSchema(schema)).to.include('z.discriminatedUnion("type"');
+    expect(serializeZodSchema(schema)).to.equal(
+      'z.discriminatedUnion("type", [' +
+        'z.object({ type: z.literal("a"), value: z.string() }), ' +
+        'z.object({ type: z.literal("b"), count: z.number() })' +
+        '])',
+    );
   });
 
   it('should serialize z.tuple() with .rest()', () => {
@@ -201,6 +206,11 @@ describe('serializeZodSchema', () => {
       },
     };
     expect(serializeZodSchema(schema)).to.equal('z.number()');
+  });
+
+  it('should fall back to z.any() for pipeline nodes without an out schema', () => {
+    // Defensive path for malformed/legacy pipe nodes: no `out` present.
+    expect(serializeZodSchema({ _def: { type: 'pipe' } })).to.equal('z.any()');
   });
 
   it('should unwrap transform pipelines when out schema only exposes def', () => {

--- a/packages/trpc/test/module/trpc-module.spec.ts
+++ b/packages/trpc/test/module/trpc-module.spec.ts
@@ -35,6 +35,51 @@ describe('TrpcModule', () => {
     });
   });
 
+  describe('forRoot (dynamic module shape)', () => {
+    it('should not be global by default and export TrpcRouter', () => {
+      const dynamicModule = TrpcModule.forRoot();
+      expect(dynamicModule.global).to.equal(false);
+      expect(dynamicModule.exports).to.deep.equal([TrpcRouter]);
+    });
+
+    it('should honor isGlobal: true', () => {
+      const dynamicModule = TrpcModule.forRoot({ isGlobal: true });
+      expect(dynamicModule.global).to.equal(true);
+    });
+  });
+
+  describe('forRootAsync (dynamic module shape)', () => {
+    const useFactory = () => ({});
+
+    it('should not be global by default and export TrpcRouter', () => {
+      const dynamicModule = TrpcModule.forRootAsync({ useFactory });
+      expect(dynamicModule.global).to.equal(false);
+      expect(dynamicModule.exports).to.deep.equal([TrpcRouter]);
+    });
+
+    it('should honor isGlobal: true', () => {
+      const dynamicModule = TrpcModule.forRootAsync({
+        useFactory,
+        isGlobal: true,
+      });
+      expect(dynamicModule.global).to.equal(true);
+    });
+
+    it('should default the options provider inject list to an empty array', () => {
+      const dynamicModule = TrpcModule.forRootAsync({ useFactory });
+      const optionsProvider = (dynamicModule.providers ?? []).find(
+        provider =>
+          typeof provider === 'object' &&
+          'provide' in provider &&
+          provider.provide === TRPC_MODULE_OPTIONS,
+      );
+      expect(optionsProvider).to.not.equal(undefined);
+      expect((optionsProvider as { inject?: unknown[] }).inject).to.deep.equal(
+        [],
+      );
+    });
+  });
+
   describe('forRootAsync', () => {
     it('should provide TrpcRouter with async options', async () => {
       const module: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
Completes the survivor-killing pass on the tRPC generators + param metadata.

**Tests (kill coverage-blind survivors).** A `param-metadata` test pins the `propertyKey` guard — an `undefined` key must not coerce to the string `"undefined"` and attach metadata to a property of that name. Plus `constants`, `decorators`, `schema-generator` (a full 140-line spec), `zod-serializer`, and `module` specs closing survivors the coverage bar didn't catch.

**Simplifications (equivalent mutants → delete the dead branch).** Dropped a redundant `'utf-8'` write encoding (Node's default) and an unused indent variable in the schema generator; folded the `any` / `lazy` / `nativeEnum` cases into the shared `z.any()` fallback in the zod serializer (all three returned `z.any()`, so the per-case branches were equivalent mutants). Behavior-neutral.

**213 passing, 100% coverage** on the touched files, complexity gate green locally (the Angular showcase `ng build` step needs Node ≥22.22.3 and is validated by GitHub CI, per the repo's known toolchain note).

**Docs.** Reframed the mutation-testing guidance (guidelines §11 + CLAUDE.md) as an **occasional, targeted audit — not a per-PR gate** (scope to one file, `--concurrency 2`, verify kills by hand-applying the mutant + running the fast mocha suite). No behavior or API change; no release.